### PR TITLE
Replace mbedtls with wolfSSL for hashing nonces

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -41,3 +41,4 @@ lib_deps =
 	https://github.com/tzapu/WiFiManager.git
 	mathertel/OneButton @ ^2.0.3
 	arduino-libraries/NTPClient
+	https://github.com/golden-guy/Arduino_wolfssl.git#v5.5.4


### PR DESCRIPTION
Using a customized wolfSSL library speeds up hashing by about 30% on the ESP32-S3, resulting in 28-29KH/s.