### PR TITLE
Wrong time after first connection

### DIFF
--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -193,8 +193,7 @@ String getTime(void){
   //Check if need an NTP call to check current time
   if((mTriggerUpdate == 0) || (millis() - mTriggerUpdate > UPDATE_PERIOD_h * 60 * 60 * 1000)){ //60 sec. * 60 min * 1000ms
     if(WiFi.status() == WL_CONNECTED) {
-        timeClient.update(); //NTP call to get current time
-        mTriggerUpdate = millis();
+        if(timeClient.update()) mTriggerUpdate = millis();
         initialTime = timeClient.getEpochTime(); // Guarda la hora inicial (en segundos desde 1970)
         Serial.print("TimeClient NTPupdateTime ");
     }


### PR DESCRIPTION
Observed that on poor wifi environment the nerdminer time is not correctly shown
Seem that timeClient.update() does not return a true, but is not checked and mTriggerUpdate is popullated with millis(). After that the NerdMiner took 5 hours to update the time.
With my pull request If the timeClient.update() function does not make a real update don't change mTriggerUpdate, this ensure that the time shown on screen at power up is updated as soon as gets connected and updated.