### PR TITLE
Save stats to NVS.

### DIFF
--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -9,14 +9,15 @@
 #include "monitor.h"
 
 extern char poolString[80];
-extern unsigned long templates;
-extern unsigned long hashes;
-extern unsigned long Mhashes;
-extern unsigned long totalKHashes;
-extern unsigned long elapsedKHs;
+extern uint32_t templates;
+extern uint32_t hashes;
+extern uint32_t Mhashes;
+extern uint32_t totalKHashes;
+extern uint32_t elapsedKHs;
+extern uint64_t upTime;
 
-extern unsigned int shares; // increase if blockhash has 32 bits of zeroes
-extern unsigned int valids; // increased if blockhash <= target
+extern uint32_t shares; // increase if blockhash has 32 bits of zeroes
+extern uint32_t valids; // increased if blockhash <= targethalfshares
 
 extern double best_diff; // track best diff
 
@@ -222,7 +223,7 @@ mining_data getMiningData(unsigned long mElapsed)
   suffix_string(best_diff, best_diff_string, 16, 0);
 
   char timeMining[15] = {0};
-  unsigned long secElapsed = millis() / 1000;
+  uint64_t secElapsed = upTime + (esp_timer_get_time() / 1000000);
   int days = secElapsed / 86400;
   int hours = (secElapsed - (days * 86400)) / 3600;               // Number of seconds in an hour
   int mins = (secElapsed - (days * 86400) - (hours * 3600)) / 60; // Remove the number of hours and calculate the minutes.
@@ -288,7 +289,6 @@ coin_data getCoinData(unsigned long mElapsed)
   unsigned long remainingBlocks = (((currentBlock / HALVING_BLOCKS) + 1) * HALVING_BLOCKS) - currentBlock;
   data.progressPercent = (HALVING_BLOCKS - remainingBlocks) * 100 / HALVING_BLOCKS;
   data.remainingBlocks = String(remainingBlocks) + " BLOCKS";
-
 
   return data;
 }


### PR DESCRIPTION
This MR store stats to NVS storage. It uses increasing time interval from 5 minutes to 12 hours to store stats. So in the long run it uses 12 hours only intervals. This interval along with the wear levelling feature of NVS api should have minimal impact of nvram lifespan and give tens of years of stats saving. Please see for details: 

https://espressif-docs.readthedocs-hosted.com/projects/esp-faq/en/latest/software-framework/storage/nvs.html

This feature can be turned on or off through WiFi settings web interface. Default is — Off

<img width="906" alt="Screenshot 2023-09-09 at 13 43 49" src="https://github.com/BitMaker-hub/NerdMiner_v2/assets/1479065/8eefe599-91df-4725-b2c9-d9c3a53bce1d">

