### PR TITLE
Lilygo S3 T-Dongle fix after TFT driver upgrade.

### DIFF
--- a/boards/lilygo-t-amoled.json
+++ b/boards/lilygo-t-amoled.json
@@ -1,0 +1,46 @@
+{
+    "build": {
+      "arduino":{
+        "ldscript": "esp32s3_out.ld",
+        "memory_type": "qio_opi",
+        "partitions": "default_16MB.csv"
+      },
+      "core": "esp32",
+      "extra_flags": [
+        "-DBOARD_HAS_PSRAM",
+        "-DARDUINO_USB_MODE=1"
+      ],
+      "f_cpu": "240000000L",
+      "f_flash": "80000000L",
+      "flash_mode": "qio",
+      "hwids": [
+        [
+          "0X303A",
+          "0x1001"
+        ]
+      ],
+      "mcu": "esp32s3",
+      "variant": "esp32s3"
+    },
+    "connectivity": [
+      "wifi",
+      "bluetooth"
+    ],
+    "debug": {
+      "openocd_target": "esp32s3.cfg"
+    },
+    "frameworks": [
+      "arduino",
+      "espidf"
+    ],
+    "name": "LILYGO T-DISPLAY-AMOLED",
+    "upload": {
+      "flash_size": "16MB",
+      "maximum_ram_size": 327680,
+      "maximum_size": 16777216,
+      "require_upload_port": true,
+      "speed": 921600
+    },
+    "url": "https://www.lilygo.cc/products/t-display-s3-amoled",
+    "vendor": "LILYGO"
+  }

--- a/lib/TFT_eSPI/User_Setup_Select.h
+++ b/lib/TFT_eSPI/User_Setup_Select.h
@@ -145,7 +145,7 @@
 #include <User_Setups/Setup211_LilyGo_T_QT_Pro_S3.h>         // For the LilyGo T-QT Pro S3 based ESP32S3 with GC9A01 128 x 128 TFT
 #endif
 #ifdef NERMINER_S3_DONGLE
-#include <User_Setups/Setup300_TTGO_T_Dongle.h>
+#include <User_Setups/Setup209_LilyGo_T_Dongle_S3.h>      // For the LilyGo T-Dongle S3 based ESP32 with ST7735 80 x 160 TFT
 #endif
 //#include <User_Setups/Setup301_BW16_ST7735.h>            // Setup file for Bw16-based boards with ST7735 160 x 80 TFT
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -101,7 +101,7 @@ lib_deps =
 
 [env:NerminerV2-S3-AMOLED]
 platform = espressif32
-board = lilygo-t-display-s3
+board = lilygo-t-amoled
 framework = arduino
 
 board_build.partitions = huge_app.csv


### PR DESCRIPTION
Lilygo S3 T-Dongle fix after TFT driver upgrade.
Board definition for Lilygo S3 AMOLED added.