### PR TITLE
run ci only on master branch, create all images and save only *.bin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 name: PlatformIO CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   build:
@@ -27,4 +30,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: builded artifacts
-          path: .pio/build/*
+          path: .pio/build/*/*.bin

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 
 [platformio]
 globallib_dir = lib
-default_envs =   ESP32-2432S028R ;NerminerV2, ESP32-devKitv1, NerminerV2-S3-DONGLE, NerminerV2-S3-AMOLED, NerminerV2-T-QT, NerdminerV2-T-Display_V1, ESP32-2432S028R
+default_envs = NerminerV2, ESP32-devKitv1, NerminerV2-S3-DONGLE, NerminerV2-S3-AMOLED, NerminerV2-T-QT, NerdminerV2-T-Display_V1, ESP32-2432S028R
 
 [env:NerminerV2]
 platform = espressif32


### PR DESCRIPTION
Run CI only on master branch.
Create images for all boards and saves only *.bin files.