### PR TITLE
fix regression introduced in 25db0a4; fix for displayDriver.h case sensitive filename

### DIFF
--- a/src/drivers/displays/amoledDisplayDriver.cpp
+++ b/src/drivers/displays/amoledDisplayDriver.cpp
@@ -1,4 +1,4 @@
-#include "DisplayDriver.h"
+#include "displayDriver.h"
 
 #ifdef AMOLED_DISPLAY
 

--- a/src/drivers/displays/display.h
+++ b/src/drivers/displays/display.h
@@ -1,7 +1,7 @@
 #ifndef DISPLAY_H
 #define DISPLAY_H
 
-#include "DisplayDriver.h"
+#include "displayDriver.h"
 
 extern DisplayDriver *currentDisplayDriver;
 

--- a/src/drivers/displays/dongleDisplayDriver.cpp
+++ b/src/drivers/displays/dongleDisplayDriver.cpp
@@ -1,4 +1,4 @@
-#include "DisplayDriver.h"
+#include "displayDriver.h"
 
 #ifdef DONGLE_DISPLAY
 

--- a/src/drivers/displays/esp23_2432s028r.cpp
+++ b/src/drivers/displays/esp23_2432s028r.cpp
@@ -1,4 +1,4 @@
-#include "DisplayDriver.h"
+#include "displayDriver.h"
 
 #ifdef ESP32_2432S028R
 

--- a/src/drivers/displays/noDisplayDriver.cpp
+++ b/src/drivers/displays/noDisplayDriver.cpp
@@ -1,4 +1,4 @@
-#include "DisplayDriver.h"
+#include "displayDriver.h"
 
 #ifdef NO_DISPLAY
 

--- a/src/drivers/displays/tDisplayDriver.cpp
+++ b/src/drivers/displays/tDisplayDriver.cpp
@@ -1,4 +1,4 @@
-#include "DisplayDriver.h"
+#include "displayDriver.h"
 
 #ifdef T_DISPLAY
 

--- a/src/drivers/displays/tDisplayV1Driver.cpp
+++ b/src/drivers/displays/tDisplayV1Driver.cpp
@@ -1,4 +1,4 @@
-#include "DisplayDriver.h"
+#include "displayDriver.h"
 
 #ifdef V1_DISPLAY
 
@@ -96,7 +96,6 @@ void tDisplay_MinerScreen(unsigned long mElapsed)
 
   // Push prepared background to screen
   background.pushSprite(0, 0);
-  background.deleteSprite();
 }
 
 void tDisplay_ClockScreen(unsigned long mElapsed)
@@ -135,7 +134,6 @@ void tDisplay_ClockScreen(unsigned long mElapsed)
 
   // Push prepared background to screen
   background.pushSprite(0, 0);
-  background.deleteSprite();
 }
 
 void tDisplay_GlobalHashScreen(unsigned long mElapsed)
@@ -195,7 +193,6 @@ void tDisplay_GlobalHashScreen(unsigned long mElapsed)
 
   // Push prepared background to screen
   background.pushSprite(0, 0);
-  background.deleteSprite();
 }
 
 void tDisplay_LoadingScreen(void)

--- a/src/drivers/displays/t_qtDisplayDriver.cpp
+++ b/src/drivers/displays/t_qtDisplayDriver.cpp
@@ -1,4 +1,4 @@
-#include "DisplayDriver.h"
+#include "displayDriver.h"
 
 #ifdef T_QT_DISPLAY
 


### PR DESCRIPTION
- fix regression introduced in 25db0a4 that prevented T-Display_V1 display to updates; 
- fix for displayDriver.h case sensitive filename as mentioned here: https://github.com/BitMaker-hub/NerdMiner_v2/issues/200