### PR TITLE
Add support to define worker name

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ After programming, you will only need to setup your Wifi and BTC address.
   "PoolUrl": "public-pool.io",  
   "PoolPort": 21496,  
   "BtcWallet": "walletID",  
+  "WorkerName": "ANiceName",
   "Timezone": 2,  
   "SaveStats": false  
 }

--- a/src/drivers/storage/SDCard.cpp
+++ b/src/drivers/storage/SDCard.cpp
@@ -101,6 +101,7 @@ bool SDCard::loadConfigFile(TSettings* Settings)
                     Settings->WifiPW = json[JSON_KEY_PASW] | Settings->WifiPW;
                     Settings->PoolAddress = json[JSON_KEY_POOLURL] | Settings->PoolAddress;
                     strcpy(Settings->BtcWallet, json[JSON_KEY_WALLETID] | Settings->BtcWallet);
+                    strcpy(Settings->WorkerName, json[JSON_KEY_WORKERID] | Settings->WorkerName);
                     if (json.containsKey(JSON_KEY_POOLPORT))
                         Settings->PoolPort = json[JSON_KEY_POOLPORT].as<int>();
                     if (json.containsKey(JSON_KEY_TIMEZONE))

--- a/src/drivers/storage/nvMemory.cpp
+++ b/src/drivers/storage/nvMemory.cpp
@@ -32,6 +32,7 @@ bool nvMemory::saveConfig(TSettings* Settings)
         json[JSON_SPIFFS_KEY_POOLURL] = Settings->PoolAddress;
         json[JSON_SPIFFS_KEY_POOLPORT] = Settings->PoolPort;
         json[JSON_SPIFFS_KEY_WALLETID] = Settings->BtcWallet;
+        json[JSON_SPIFFS_KEY_WORKERID] = Settings->WorkerName;
         json[JSON_SPIFFS_KEY_TIMEZONE] = Settings->Timezone;
         json[JSON_SPIFFS_KEY_STATS2NV] = Settings->saveStats;
 
@@ -89,6 +90,7 @@ bool nvMemory::loadConfig(TSettings* Settings)
                 {
                     Settings->PoolAddress = json[JSON_SPIFFS_KEY_POOLURL] | Settings->PoolAddress;
                     strcpy(Settings->BtcWallet, json[JSON_SPIFFS_KEY_WALLETID] | Settings->BtcWallet);
+                    strcpy(Settings->WorkerName, json[JSON_SPIFFS_KEY_WORKERID] | Settings->WorkerName);
                     if (json.containsKey(JSON_SPIFFS_KEY_POOLPORT))
                         Settings->PoolPort = json[JSON_SPIFFS_KEY_POOLPORT].as<int>();
                     if (json.containsKey(JSON_SPIFFS_KEY_TIMEZONE))

--- a/src/drivers/storage/storage.h
+++ b/src/drivers/storage/storage.h
@@ -10,6 +10,7 @@
 #define DEFAULT_WIFIPW		"MineYourCoins"
 #define DEFAULT_POOLURL		"public-pool.io"
 #define DEFAULT_WALLETID	"yourBtcAddress"
+#define DEFAULT_WORKERID	""
 #define DEFAULT_POOLPORT	21496
 #define DEFAULT_TIMEZONE	2
 #define DEFAULT_SAVESTATS	false
@@ -22,6 +23,7 @@
 #define JSON_KEY_PASW		"WifiPW"
 #define JSON_KEY_POOLURL	"PoolUrl"
 #define JSON_KEY_WALLETID	"BtcWallet"
+#define JSON_KEY_WORKERID	"WorkerName"
 #define JSON_KEY_POOLPORT	"PoolPort"
 #define JSON_KEY_TIMEZONE	"Timezone"
 #define JSON_KEY_STATS2NV	"SaveStats"
@@ -30,6 +32,7 @@
 #define JSON_SPIFFS_KEY_POOLURL		"poolString"
 #define JSON_SPIFFS_KEY_POOLPORT	"portNumber"
 #define JSON_SPIFFS_KEY_WALLETID	"btcString"
+#define JSON_SPIFFS_KEY_WORKERID	"workerName"
 #define JSON_SPIFFS_KEY_TIMEZONE	"gmtZone"
 #define JSON_SPIFFS_KEY_STATS2NV	"saveStatsToNVS"
 
@@ -40,6 +43,7 @@ struct TSettings
 	String WifiPW{ DEFAULT_WIFIPW };
 	String PoolAddress{ DEFAULT_POOLURL };
 	char BtcWallet[80]{ DEFAULT_WALLETID };
+	char WorkerName[20]{ DEFAULT_WORKERID };
 	int PoolPort{ DEFAULT_POOLPORT };
 	int Timezone{ DEFAULT_TIMEZONE };
 	bool saveStats{ DEFAULT_SAVESTATS };

--- a/src/mining.cpp
+++ b/src/mining.cpp
@@ -166,10 +166,12 @@ void runStratumWorker(void *name) {
         continue; 
       }
       
-      strcpy(mWorker.wName, Settings.BtcWallet);
       if (strlen(Settings.WorkerName) > 0) {
-        snprintf(mWorker.wName, sizeof(mWorker.wName), ".%s", Settings.WorkerName);
+        snprintf(mWorker.wName, sizeof(mWorker.wName), "%s.%s", Settings.BtcWallet, Settings.WorkerName);
+      } else {
+        strcpy(mWorker.wName, Settings.BtcWallet);
       }
+      Serial.println(mWorker.wName);
       
       strcpy(mWorker.wPass, "x");
       // STEP 2: Pool authorize work (Block Info)

--- a/src/mining.cpp
+++ b/src/mining.cpp
@@ -171,7 +171,6 @@ void runStratumWorker(void *name) {
       } else {
         strcpy(mWorker.wName, Settings.BtcWallet);
       }
-      Serial.println(mWorker.wName);
       
       strcpy(mWorker.wPass, "x");
       // STEP 2: Pool authorize work (Block Info)

--- a/src/mining.cpp
+++ b/src/mining.cpp
@@ -167,6 +167,10 @@ void runStratumWorker(void *name) {
       }
       
       strcpy(mWorker.wName, Settings.BtcWallet);
+      if (strlen(Settings.WorkerName) > 0) {
+        snprintf(mWorker.wName, sizeof(mWorker.wName), ".%s", Settings.WorkerName);
+      }
+      
       strcpy(mWorker.wPass, "x");
       // STEP 2: Pool authorize work (Block Info)
       tx_mining_auth(client, mWorker.wName, mWorker.wPass); //Don't verifies authoritzation, TODO

--- a/src/wManager.cpp
+++ b/src/wManager.cpp
@@ -137,6 +137,9 @@ void init_WifiManager()
     // Text box (String) - 80 characters maximum
     WiFiManagerParameter addr_text_box("btcAddress", "Your BTC address", Settings.BtcWallet, 80);
 
+    // Text box (String) - 20 character maximum
+    WiFiManagerParameter worker_text_box("workerName", "Worker Name", Settings.WorkerName, 20);
+
   // Text box (Number) - 2 characters maximum
   char charZone[6];
   sprintf(charZone, "%d", Settings.Timezone);
@@ -155,6 +158,7 @@ void init_WifiManager()
   wm.addParameter(&pool_text_box);
   wm.addParameter(&port_text_box_num);
   wm.addParameter(&addr_text_box);
+  wm.addParameter(&worker_text_box);
   wm.addParameter(&time_text_box_num);
   wm.addParameter(&features_html);
   wm.addParameter(&save_stats_to_nvs);
@@ -174,6 +178,7 @@ void init_WifiManager()
             Settings.PoolAddress = pool_text_box.getValue();
             Settings.PoolPort = atoi(port_text_box_num.getValue());
             strncpy(Settings.BtcWallet, addr_text_box.getValue(), sizeof(Settings.BtcWallet));
+            strncpy(Settings.WorkerName, worker_text_box.getValue(), sizeof(Settings.WorkerName));
             Settings.Timezone = atoi(time_text_box_num.getValue());
             Serial.println(save_stats_to_nvs.getValue());
             Settings.saveStats = (strncmp(save_stats_to_nvs.getValue(), "T", 1) == 0);
@@ -227,6 +232,11 @@ void init_WifiManager()
         strncpy(Settings.BtcWallet, addr_text_box.getValue(), sizeof(Settings.BtcWallet));
         Serial.print("btcString: ");
         Serial.println(Settings.BtcWallet);
+
+        // Copy the string value
+        strncpy(Settings.WorkerName, worker_text_box.getValue(), sizeof(Settings.WorkerName));
+        Serial.print("workerName: ");
+        Serial.println(Settings.WorkerName);
 
         //Convert the number value
         Settings.Timezone = atoi(time_text_box_num.getValue());


### PR DESCRIPTION
Introduce support to define, optionally, a custom name for the worker.
If empty or not set `worker` will be used as fallback by the pool.