### PR TITLE
Show Total Workers HashRate in Home

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ After programming, you will only need to setup your Wifi and BTC address.
   "PoolPort": 21496,  
   "BtcWallet": "walletID",  
   "Timezone": 2,  
-  "SaveStats": false  
+  "SaveStats": false,
+  "TotalHash": false
 }
 1. Insert the SD card.
 1. Hold down the "reset configurations" button as described below to reset the configurations and/or boot without settings in your nvmemory.

--- a/src/drivers/displays/tDisplayDriver.cpp
+++ b/src/drivers/displays/tDisplayDriver.cpp
@@ -9,6 +9,7 @@
 #include "version.h"
 #include "monitor.h"
 #include "OpenFontRender.h"
+#include "drivers/storage/storage.h"
 
 #define WIDTH 340
 #define HEIGHT 170
@@ -16,6 +17,8 @@
 OpenFontRender render;
 TFT_eSPI tft = TFT_eSPI();                  // Invoke library, pins defined in User_Setup.h
 TFT_eSprite background = TFT_eSprite(&tft); // Invoke library sprite
+
+extern TSettings Settings; 
 
 void tDisplay_Init(void)
 {
@@ -53,7 +56,7 @@ void tDisplay_MinerScreen(unsigned long mElapsed)
   mining_data data = getMiningData(mElapsed);
   pool_data poolData = getPoolData();
 
-  bool showTotalWorkerHashRate = false;
+  bool showTotalWorkerHashRate = Settings.TotalHash;
 
   // Print background screen
   background.pushImage(0, 0, MinerWidth, MinerHeight, MinerScreen);

--- a/src/drivers/displays/tDisplayDriver.cpp
+++ b/src/drivers/displays/tDisplayDriver.cpp
@@ -51,6 +51,9 @@ void tDisplay_AlternateRotation(void)
 void tDisplay_MinerScreen(unsigned long mElapsed)
 {
   mining_data data = getMiningData(mElapsed);
+  pool_data poolData = getPoolData();
+
+  bool showTotalWorkerHashRate = false;
 
   // Print background screen
   background.pushImage(0, 0, MinerWidth, MinerHeight, MinerScreen);
@@ -59,11 +62,11 @@ void tDisplay_MinerScreen(unsigned long mElapsed)
                 data.completedShares.c_str(), data.totalKHashes.c_str(), data.currentHashRate.c_str());
 
   // Hashrate
-  render.setFontSize(35);
+  render.setFontSize(showTotalWorkerHashRate ? 25 : 35);
   render.setCursor(19, 118);
   render.setFontColor(TFT_BLACK);
 
-  render.rdrawString(data.currentHashRate.c_str(), 118, 114, TFT_BLACK);
+  render.rdrawString(showTotalWorkerHashRate ? poolData.workersHash.c_str() : data.currentHashRate.c_str(), 118, 114, TFT_BLACK);
   // Total hashes
   render.setFontSize(18);
   render.rdrawString(data.totalMHashes.c_str(), 268, 138, TFT_BLACK);
@@ -101,6 +104,7 @@ void tDisplay_MinerScreen(unsigned long mElapsed)
 void tDisplay_ClockScreen(unsigned long mElapsed)
 {
   clock_data data = getClockData(mElapsed);
+  pool_data poolData = getPoolData();
 
   // Print background screen
   background.pushImage(0, 0, minerClockWidth, minerClockHeight, minerClockScreen);

--- a/src/drivers/storage/SDCard.cpp
+++ b/src/drivers/storage/SDCard.cpp
@@ -107,6 +107,8 @@ bool SDCard::loadConfigFile(TSettings* Settings)
                         Settings->Timezone = json[JSON_KEY_TIMEZONE].as<int>();
                     if (json.containsKey(JSON_KEY_STATS2NV))
                         Settings->saveStats = json[JSON_KEY_STATS2NV].as<bool>();
+                    if (json.containsKey(JSON_KEY_TOTALHASH))
+                        Settings->saveStats = json[JSON_KEY_TOTALHASH].as<bool>();
                     return true;
                 }
                 else

--- a/src/drivers/storage/nvMemory.cpp
+++ b/src/drivers/storage/nvMemory.cpp
@@ -34,6 +34,7 @@ bool nvMemory::saveConfig(TSettings* Settings)
         json[JSON_SPIFFS_KEY_WALLETID] = Settings->BtcWallet;
         json[JSON_SPIFFS_KEY_TIMEZONE] = Settings->Timezone;
         json[JSON_SPIFFS_KEY_STATS2NV] = Settings->saveStats;
+        json[JSON_SPIFFS_KEY_TOTALHASH] = Settings->TotalHash;
 
         // Open config file
         File configFile = SPIFFS.open(JSON_CONFIG_FILE, "w");
@@ -95,6 +96,8 @@ bool nvMemory::loadConfig(TSettings* Settings)
                         Settings->Timezone = json[JSON_SPIFFS_KEY_TIMEZONE].as<int>();
                     if (json.containsKey(JSON_SPIFFS_KEY_STATS2NV))
                         Settings->saveStats = json[JSON_SPIFFS_KEY_STATS2NV].as<bool>();
+                    if (json.containsKey(JSON_SPIFFS_KEY_TOTALHASH))
+                        Settings->TotalHash = json[JSON_SPIFFS_KEY_TOTALHASH].as<bool>();
                     return true;
                 }
                 else

--- a/src/drivers/storage/storage.h
+++ b/src/drivers/storage/storage.h
@@ -13,6 +13,7 @@
 #define DEFAULT_POOLPORT	21496
 #define DEFAULT_TIMEZONE	2
 #define DEFAULT_SAVESTATS	false
+#define DEFAULT_TOTALHASH	false
 
 // JSON config files
 #define JSON_CONFIG_FILE	"/config.json"
@@ -25,6 +26,7 @@
 #define JSON_KEY_POOLPORT	"PoolPort"
 #define JSON_KEY_TIMEZONE	"Timezone"
 #define JSON_KEY_STATS2NV	"SaveStats"
+#define JSON_KEY_TOTALHASH	"TotalHash"
 
 // JSON config file SPIFFS (different for backward compatibility with existing devices)
 #define JSON_SPIFFS_KEY_POOLURL		"poolString"
@@ -32,6 +34,7 @@
 #define JSON_SPIFFS_KEY_WALLETID	"btcString"
 #define JSON_SPIFFS_KEY_TIMEZONE	"gmtZone"
 #define JSON_SPIFFS_KEY_STATS2NV	"saveStatsToNVS"
+#define JSON_SPIFFS_KEY_TOTALHASH	"totalHash"
 
 // settings
 struct TSettings
@@ -43,6 +46,7 @@ struct TSettings
 	int PoolPort{ DEFAULT_POOLPORT };
 	int Timezone{ DEFAULT_TIMEZONE };
 	bool saveStats{ DEFAULT_SAVESTATS };
+	bool TotalHash{ DEFAULT_TOTALHASH };
 };
 
 #endif // _STORAGE_H_

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -214,7 +214,7 @@ mining_data getMiningData(unsigned long mElapsed)
   mining_data data;
 
   char best_diff_string[16] = {0};
-  suffix_string(best_diff, best_diff_string, 16, 0);
+  suffix_string(best_diff, best_diff_string, 16, 0, true);
 
   char timeMining[15] = {0};
   uint64_t secElapsed = upTime + (esp_timer_get_time() / 1000000);
@@ -322,14 +322,14 @@ pool_data getPoolData(void){
                 Serial.println(totalhashs); */
               }
               char totalhashs_s[16] = {0};
-              suffix_string(totalhashs, totalhashs_s, 16, 0);
+              suffix_string(totalhashs, totalhashs_s, 16, 0, false);
               pData.workersHash = String(totalhashs_s);
 
               double temp;
               if (doc.containsKey("bestDifficulty")) {
               temp = doc["bestDifficulty"].as<double>();            
               char best_diff_string[16] = {0};
-              suffix_string(temp, best_diff_string, 16, 0);
+              suffix_string(temp, best_diff_string, 16, 0, true);
               pData.bestDifficulty = String(best_diff_string);
               }
               doc.clear();

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -398,7 +398,7 @@ miner_data calculateMiningData(mining_subscribe& mWorker, mining_job mJob){
 
 /* Convert a double value into a truncated string for displaying with its
  * associated suitable for Mega, Giga etc. Buf array needs to be long enough */
-void suffix_string(double val, char *buf, size_t bufsiz, int sigdigits)
+void suffix_string(double val, char *buf, size_t bufsiz, int sigdigits, bool addsuffix)
 {
 	const double kilo = 1000;
 	const double mega = 1000000;
@@ -441,6 +441,10 @@ void suffix_string(double val, char *buf, size_t bufsiz, int sigdigits)
 		if (dval < min_diff)
 			dval = 0.0;
 	}
+
+    if (!addsuffix) {
+        strcpy(suffix, "");
+    }
 
 	if (!sigdigits) {
 		if (decimal)

--- a/src/utils.h
+++ b/src/utils.h
@@ -22,7 +22,7 @@ double le256todouble(const void *target);
 double diff_from_target(void *target);
 miner_data calculateMiningData(mining_subscribe& mWorker, mining_job mJob);
 bool checkValid(unsigned char* hash, unsigned char* target);
-void suffix_string(double val, char *buf, size_t bufsiz, int sigdigits);
+void suffix_string(double val, char *buf, size_t bufsiz, int sigdigits, bool addsuffix);
 
 
 

--- a/src/wManager.cpp
+++ b/src/wManager.cpp
@@ -151,6 +151,14 @@ void init_WifiManager()
   }
   WiFiManagerParameter save_stats_to_nvs("SaveStatsToNVS", "Track Uptime, Best Diff, Total Hashes in device Flash memory. (Experimental)", "T", 2, checkboxParams, WFM_LABEL_AFTER);
 
+  char showTotalHashParams[24] = "type=\"checkbox\"";
+  if (Settings.TotalHash)
+  {
+    strcat(showTotalHashParams, " checked");
+  }
+  WiFiManagerParameter show_total_hash("TotalHash", "Show total workers hash rate in home", "T", 2, showTotalHashParams, WFM_LABEL_AFTER);
+
+
   // Add all defined parameters
   wm.addParameter(&pool_text_box);
   wm.addParameter(&port_text_box_num);
@@ -158,6 +166,7 @@ void init_WifiManager()
   wm.addParameter(&time_text_box_num);
   wm.addParameter(&features_html);
   wm.addParameter(&save_stats_to_nvs);
+  wm.addParameter(&show_total_hash);
 
     Serial.println("AllDone: ");
     if (forceConfig)    
@@ -177,6 +186,8 @@ void init_WifiManager()
             Settings.Timezone = atoi(time_text_box_num.getValue());
             Serial.println(save_stats_to_nvs.getValue());
             Settings.saveStats = (strncmp(save_stats_to_nvs.getValue(), "T", 1) == 0);
+            Serial.println(show_total_hash.getValue());
+            Settings.TotalHash = (strncmp(show_total_hash.getValue(), "T", 1) == 0);
 
             nvMem.saveConfig(&Settings);
             delay(3000);


### PR DESCRIPTION
This PR introduces a new option in the web configuration menu.
If the user tick the option to show all the total workers in home, instead of just the current worker, the sum of all the workers for the current BTC account will be shown.
Default behaviour is showing the current worker only.

Why?
Sometimes ppl can have a rig of devices and can be nice to use the LCD to see what's the current of the overall setup.

And if I enable it and I want to see also my current performance? For now you can just switch to the clock view.

Limitation:
- It support only the LILYGO S3 LCD for now