### PR TITLE
Add support Lilygo T-Embed board

### DIFF
--- a/lib/TFT_eSPI/User_Setup_Select.h
+++ b/lib/TFT_eSPI/User_Setup_Select.h
@@ -142,7 +142,9 @@
 //#include <User_Setups/Setup208_ESP32_S3_Box_Lite.h>      // For the ESP32 S3 Box Lite (may also work with ESP32 S3 Box)
 
 //#include <User_Setups/Setup209_LilyGo_T_Dongle_S3.h>      // For the LilyGo T-Dongle S3 based ESP32 with ST7735 80 x 160 TFT
-// #include <User_Setups/Setup210_LilyGo_T_Embed_S3.h>         // For the LilyGo T-Embed S3 based ESP32S3 with ST7789 170 x 320 TFT
+#ifdef LILYGO_S3_T_EMBED
+#include <User_Setups/Setup210_LilyGo_T_Embed_S3.h>         // For the LilyGo T-Embed S3 based ESP32S3 with ST7789 170 x 320 TFT
+#endif
 #ifdef NERMINER_T_QT
 #include <User_Setups/Setup211_LilyGo_T_QT_Pro_S3.h>         // For the LilyGo T-QT Pro S3 based ESP32S3 with GC9A01 128 x 128 TFT
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 
 [platformio]
 globallib_dir = lib
-default_envs = M5Stick-C, esp32cam, ESP32-2432S028R, NerminerV2, ESP32-devKitv1, NerminerV2-S3-DONGLE, NerminerV2-S3-AMOLED, NerminerV2-T-QT, NerdminerV2-T-Display_V1, ESP32-2432S028R, M5-StampS3, ESP32-S3-devKitv1, ESP32-S3-mini-wemos, ESP32-S3-mini-weact, ESP32-C3-devKitmv1, ESP32-C3-super-mini
+default_envs = M5Stick-C, esp32cam, ESP32-2432S028R, NerminerV2, Lilygo-T-Embed, ESP32-devKitv1, NerminerV2-S3-DONGLE, NerminerV2-S3-AMOLED, NerminerV2-T-QT, NerdminerV2-T-Display_V1, ESP32-2432S028R, M5-StampS3, ESP32-S3-devKitv1, ESP32-S3-mini-wemos, ESP32-S3-mini-weact, ESP32-C3-devKitmv1, ESP32-C3-super-mini
 
 [env:M5Stick-C]
 platform = espressif32
@@ -215,6 +215,39 @@ build_flags =
 	-D ARDUINO_USB_MODE=1
 	-D ARDUINO_USB_CDC_ON_BOOT=1
 	-D NERDMINERV2=1
+	;-D DEBUG_MINING=1
+lib_deps = 
+	https://github.com/takkaO/OpenFontRender
+	bblanchon/ArduinoJson@^6.21.2
+	https://github.com/tzapu/WiFiManager.git#v2.0.16-rc.2
+	mathertel/OneButton @ ^2.0.3
+	arduino-libraries/NTPClient
+	;https://github.com/golden-guy/Arduino_wolfssl.git#v5.5.4
+
+;--------------------------------------------------------------------
+
+[env:Lilygo-T-Embed]
+platform = espressif32
+board = esp32-s3-devkitc-1
+framework = arduino
+monitor_filters = 
+	esp32_exception_decoder
+	time
+	log2file
+board_build.arduino.memory_type = qio_opi
+monitor_speed = 115200
+upload_speed = 115200
+# 2 x 4.5MB app, 6.875MB SPIFFS
+;board_build.partitions = large_spiffs_16MB.csv
+;board_build.partitions = default_8MB.csv
+board_build.partitions = huge_app.csv
+;board_build.partitions = default.csv
+build_flags = 
+	-D LV_LVGL_H_INCLUDE_SIMPLE
+	-D BOARD_HAS_PSRAM
+	-D ARDUINO_USB_MODE=1
+	-D ARDUINO_USB_CDC_ON_BOOT=1
+	-D LILYGO_S3_T_EMBED=1
 	;-D DEBUG_MINING=1
 lib_deps = 
 	https://github.com/takkaO/OpenFontRender

--- a/src/drivers/devices/device.h
+++ b/src/drivers/devices/device.h
@@ -13,6 +13,8 @@
 #include "lilygoS3Amoled.h"
 #elif defined(NERMINER_S3_DONGLE)
 #include "lilygoS3Dongle.h"
+#elif defined(LILYGO_S3_T_EMBED)
+#include "lilygoS3TEmbed.h"
 #elif defined(ESP32_2432S028R)
 #include "esp322432s028r.h"
 #elif defined(NERMINER_T_QT)

--- a/src/drivers/devices/lilygoS3TEmbed.h
+++ b/src/drivers/devices/lilygoS3TEmbed.h
@@ -1,0 +1,10 @@
+#ifndef _LILYGO_S3_T_EMBED_H
+#define _LILYGO_S3_T_EMBED_H
+
+#define PIN_BUTTON_1 0
+// #define PIN_BUTTON_2 14
+#define PIN_ENABLE5V 46
+
+#define T_DISPLAY
+
+#endif

--- a/src/drivers/devices/lilygoS3TEmbed.h
+++ b/src/drivers/devices/lilygoS3TEmbed.h
@@ -2,7 +2,6 @@
 #define _LILYGO_S3_T_EMBED_H
 
 #define PIN_BUTTON_1 0
-// #define PIN_BUTTON_2 14
 #define PIN_ENABLE5V 46
 
 #define T_DISPLAY

--- a/src/drivers/displays/tDisplayDriver.cpp
+++ b/src/drivers/displays/tDisplayDriver.cpp
@@ -20,7 +20,11 @@ TFT_eSprite background = TFT_eSprite(&tft); // Invoke library sprite
 void tDisplay_Init(void)
 {
   tft.init();
+  #ifdef LILYGO_S3_T_EMBED
+  tft.setRotation(3);
+  #else
   tft.setRotation(1);
+  #endif
   tft.setSwapBytes(true);                 // Swap the colour byte order when rendering
   background.createSprite(WIDTH, HEIGHT); // Background Sprite
   background.setSwapBytes(true);


### PR DESCRIPTION
**Add support Lilygo T-Embed board with single central button without using the rotary encoder**

![original_06ff2843-fa3d-471f-bed2-5dc81c46d11f_IMG_20240110_164358](https://github.com/BitMaker-hub/NerdMiner_v2/assets/3461323/078be600-d6e1-453d-8f4b-62d1fd93ceee)

