### PR TITLE
Updated esp322432s028r.h with SD card interface pin defines

### DIFF
--- a/src/drivers/devices/esp322432s028r.h
+++ b/src/drivers/devices/esp322432s028r.h
@@ -7,4 +7,16 @@
 #define LED_PIN      4   // Red pin
 #define LED_PIN_G    17  // Green pin
 
+// Pin defines for the SD card interface
+// This is working 
+// --------------------------------------
+// use SPI interface
+// (default SPI unit provided by <SPI.h>)
+// setup SPI pins.
+
+#define SDSPI_CS    5
+#define SDSPI_CLK   18
+#define SDSPI_MOSI  23
+#define SDSPI_MISO  19
+
 #endif

--- a/src/drivers/devices/esp322432s028r.h
+++ b/src/drivers/devices/esp322432s028r.h
@@ -8,7 +8,7 @@
 #define LED_PIN_G    17  // Green pin
 
 // Pin defines for the SD card interface
-// This is working 
+// This is working for both, ESP32 2432S028R and ESP 2432S028_2USB boards 
 // --------------------------------------
 // use SPI interface
 // (default SPI unit provided by <SPI.h>)


### PR DESCRIPTION
Added SD card interface pin defines for the ESP32 2432S028R and ESP 2432S028_2USB boards. 
Tested successfully with both above mentioned boards.