### PR TITLE
Store and restore screen settings cross reboots

### DIFF
--- a/src/drivers/displays/amoledDisplayDriver.cpp
+++ b/src/drivers/displays/amoledDisplayDriver.cpp
@@ -52,10 +52,16 @@ void amoledDisplay_AlternateScreenState(void)
 }
 
 int screen_rotation = 1;
-void amoledDisplay_AlternateRotation(void)
+int amoledDisplay_AlternateRotation(void)
 {
   screen_rotation == 1 ? lcd_setRotation(3) : lcd_setRotation(1);
   screen_rotation ^= 1;
+  return screen_rotation;
+}
+
+void amoledDisplay_SetRotation(int rotation)
+{
+  lcd_setRotation(rotation);
 }
 
 void amoledDisplay_MinerScreen(unsigned long mElapsed)
@@ -234,6 +240,7 @@ DisplayDriver amoledDisplayDriver = {
     amoledDisplay_Init,
     amoledDisplay_AlternateScreenState,
     amoledDisplay_AlternateRotation,
+    amoledDisplay_SetRotation,
     amoledDisplay_LoadingScreen,
     amoledDisplay_SetupScreen,
     amoledDisplayCyclicScreens,

--- a/src/drivers/displays/display.cpp
+++ b/src/drivers/displays/display.cpp
@@ -1,4 +1,11 @@
 #include "display.h"
+#include "../storage/storage.h"
+#include "../storage/nvMemory.h"
+
+// Variables to hold data from custom textboxes
+//Track mining stats in non volatile memory
+extern TSettings Settings;
+extern nvMemory nvMem;
 
 #ifdef NO_DISPLAY
 DisplayDriver *currentDisplayDriver = &noDisplayDriver;
@@ -44,7 +51,22 @@ DisplayDriver *currentDisplayDriver = &m5stickCDriver;
 // Initialize the display
 void initDisplay()
 {
+  Serial.println("Starting display.");
   currentDisplayDriver->initDisplay();
+  if (!nvMem.loadConfig(&Settings)) {
+    return;
+  }
+
+  if (Settings.screenOrientation>=0) {
+    Serial.println("Setting stored screen orientation.");
+    Serial.println(Settings.screenOrientation);
+    currentDisplayDriver->setRotation(Settings.screenOrientation);
+  } else {
+    Serial.println("No stored screen orientation");
+    Serial.println(Settings.screenOrientation);
+    currentDisplayDriver->setRotation(0);
+  
+  }
 }
 
 // Alternate screen state
@@ -56,7 +78,9 @@ void alternateScreenState()
 // Alternate screen rotation
 void alternateScreenRotation()
 {
-  currentDisplayDriver->alternateScreenRotation();
+  int screen_rotation = currentDisplayDriver->alternateScreenRotation();
+  Settings.screenOrientation = screen_rotation;
+  nvMem.saveConfig(&Settings);
 }
 
 // Draw the loading screen

--- a/src/drivers/displays/display.cpp
+++ b/src/drivers/displays/display.cpp
@@ -65,8 +65,17 @@ void initDisplay()
     Serial.println("No stored screen orientation");
     Serial.println(Settings.screenOrientation);
     currentDisplayDriver->setRotation(0);
-  
   }
+
+    if (Settings.currentCyclicScreen>=0) {
+    Serial.println("Setting stored screen.");
+    Serial.println(Settings.currentCyclicScreen);
+    currentDisplayDriver->current_cyclic_screen = Settings.currentCyclicScreen;
+  } else {
+    Serial.println("No stored screen.");
+    Serial.println(Settings.currentCyclicScreen);  
+  }
+
 }
 
 // Alternate screen state
@@ -105,6 +114,8 @@ void resetToFirstScreen()
 void switchToNextScreen()
 {
   currentDisplayDriver->current_cyclic_screen = (currentDisplayDriver->current_cyclic_screen + 1) % currentDisplayDriver->num_cyclic_screens;
+  Settings.currentCyclicScreen = currentDisplayDriver->current_cyclic_screen;
+  nvMem.saveConfig(&Settings);
 }
 
 // Draw the current cyclic screen

--- a/src/drivers/displays/displayDriver.h
+++ b/src/drivers/displays/displayDriver.h
@@ -4,6 +4,8 @@
 #include "../devices/device.h"
 
 typedef void (*AlternateFunction)(void);
+typedef int (*AlternateRotationFunction)(void);
+typedef void (*SetRotationFunction)(int rotation);
 typedef void (*DriverInitFunction)(void);
 typedef void (*ScreenFunction)(void);
 typedef void (*CyclicScreenFunction)(unsigned long mElapsed);
@@ -14,7 +16,8 @@ typedef struct
 {
   DriverInitFunction initDisplay;                    // Initialize the display
   AlternateFunction alternateScreenState;            // Alternate screen state
-  AlternateFunction alternateScreenRotation;         // Alternate screen rotation
+  AlternateRotationFunction alternateScreenRotation;         // Alternate screen rotation
+  SetRotationFunction setRotation;                   // Set the rotation
   ScreenFunction loadingScreen;                      // Explicit loading screen
   ScreenFunction setupScreen;                        // Explicit setup screen
   CyclicScreenFunction *cyclic_screens;              // Array of cyclic screens

--- a/src/drivers/displays/dongleDisplayDriver.cpp
+++ b/src/drivers/displays/dongleDisplayDriver.cpp
@@ -108,9 +108,16 @@ void dongleDisplay_AlternateScreenState(void)
   digitalWrite(TFT_BL, !screen_state);
 }
 
-void dongleDisplay_AlternateRotation(void)
+int dongleDisplay_AlternateRotation(void)
 {
-  tft.getRotation() == 1 ? tft.setRotation(3) : tft.setRotation(1);
+  int screen_rotation = tft.getRotation() == 1 ? 3 : 1;
+  tft.setRotation(screen_rotation); 
+  return screen_rotation;
+}
+
+void dongledDisplay_SetRotation(int rotation)
+{
+  tft.setRotation(rotation);
 }
 
 void dongleDisplay_MinerScreen(unsigned long mElapsed)
@@ -215,6 +222,7 @@ DisplayDriver dongleDisplayDriver = {
     dongleDisplay_Init,
     dongleDisplay_AlternateScreenState,
     dongleDisplay_AlternateRotation,
+    dongleDisplay_SetRotation,
     dongleDisplay_LoadingScreen,
     dongleDisplay_SetupScreen,
     dongleDisplayCyclicScreens,

--- a/src/drivers/displays/dongleDisplayDriver.cpp
+++ b/src/drivers/displays/dongleDisplayDriver.cpp
@@ -115,7 +115,7 @@ int dongleDisplay_AlternateRotation(void)
   return screen_rotation;
 }
 
-void dongledDisplay_SetRotation(int rotation)
+void dongleDisplay_SetRotation(int rotation)
 {
   tft.setRotation(rotation);
 }

--- a/src/drivers/displays/esp23_2432s028r.cpp
+++ b/src/drivers/displays/esp23_2432s028r.cpp
@@ -77,10 +77,17 @@ void esp32_2432S028R_AlternateScreenState(void)
   digitalWrite(TFT_BL, !screen_state);
 }
 
-void esp32_2432S028R_AlternateRotation(void)
+int esp32_2432S028R_AlternateRotation(void)
 {
-  tft.getRotation() == 1 ? tft.setRotation(3) : tft.setRotation(1);
+  int screen_rotation = tft.getRotation() == 1 ? 3 : 1;
+  tft.setRotation(screen_rotation);
   hasChangedScreen = true;
+  return screen_rotation;
+}
+
+void esp32_2432S028R_SetRotation(int rotation)
+{
+  tft.setRotation(rotation);
 }
 
 bool bottomScreenBlue = true;
@@ -522,6 +529,7 @@ DisplayDriver esp32_2432S028RDriver = {
     esp32_2432S028R_Init,
     esp32_2432S028R_AlternateScreenState,
     esp32_2432S028R_AlternateRotation,
+    esp32_2432S028R_SetRotation,
     esp32_2432S028R_LoadingScreen,
     esp32_2432S028R_SetupScreen,
     esp32_2432S028RCyclicScreens,

--- a/src/drivers/displays/ledDisplayDriver.cpp
+++ b/src/drivers/displays/ledDisplayDriver.cpp
@@ -39,8 +39,14 @@ void ledDisplay_AlternateScreenState(void)
   ledOn = !ledOn;
 }
 
-void ledDisplay_AlternateRotation(void)
+int ledDisplay_AlternateRotation(void)
 {
+  return 0;
+}
+
+void ledDisplay_SetRotation(int rotation)
+{
+  return;
 }
 
 void ledDisplay_NoScreen(unsigned long mElapsed)
@@ -125,6 +131,7 @@ DisplayDriver ledDisplayDriver = {
     ledDisplay_Init,
     ledDisplay_AlternateScreenState,
     ledDisplay_AlternateRotation,
+    ledDisplay_SetRotation,
     ledDisplay_LoadingScreen,
     ledDisplay_SetupScreen,
     ledDisplayCyclicScreens,

--- a/src/drivers/displays/m5stickCDriver.cpp
+++ b/src/drivers/displays/m5stickCDriver.cpp
@@ -52,7 +52,7 @@ int m5stickCDriver_AlternateRotation(void)
   return screen_rotation;
 }
 
-void dongledDisplay_SetRotation(int rotation)
+void m5stickCDriver_SetRotation(int rotation)
 {
   m5.Lcd.setRotation(rotation);
 }

--- a/src/drivers/displays/m5stickCDriver.cpp
+++ b/src/drivers/displays/m5stickCDriver.cpp
@@ -40,10 +40,21 @@ void m5stickCDriver_AlternateScreenState(void)
   }
 }
 
-void m5stickCDriver_AlternateRotation(void)
+int m5stickCDriver_AlternateRotation(void)
 {
-  if (M5.Lcd.getRotation() == 3) M5.Lcd.setRotation(1);
-  else M5.Lcd.setRotation(3);
+  int screen_rotation;
+  if (M5.Lcd.getRotation() == 3) 
+    screen_rotation = 1;
+  else 
+    screen_rotation = 3;
+    
+  m5.Lcd.setRotation(screen_rotation);
+  return screen_rotation;
+}
+
+void dongledDisplay_SetRotation(int rotation)
+{
+  m5.Lcd.setRotation(rotation);
 }
 
 void m5stickCDriver_MinerScreen(unsigned long mElapsed)
@@ -189,6 +200,7 @@ DisplayDriver m5stickCDriver = {
     m5stickCDriver_Init,
     m5stickCDriver_AlternateScreenState,
     m5stickCDriver_AlternateRotation,
+    m5stickCDriver_SetRotation,
     m5stickCDriver_LoadingScreen,
     m5stickCDriver_SetupScreen,
     m5stickCDriverCyclicScreens,

--- a/src/drivers/displays/noDisplayDriver.cpp
+++ b/src/drivers/displays/noDisplayDriver.cpp
@@ -18,8 +18,14 @@ void noDisplay_AlternateScreenState(void)
 {
 }
 
-void noDisplay_AlternateRotation(void)
+int noDisplay_AlternateRotation(void)
 {
+  return 0;
+}
+
+void noDisplay_SetRotation(int rotation)
+{
+  return;
 }
 
 void noDisplay_NoScreen(unsigned long mElapsed)
@@ -91,6 +97,7 @@ DisplayDriver noDisplayDriver = {
     noDisplay_Init,
     noDisplay_AlternateScreenState,
     noDisplay_AlternateRotation,
+    noDisplay_SetRotation,
     noDisplay_LoadingScreen,
     noDisplay_SetupScreen,
     noDisplayCyclicScreens,

--- a/src/drivers/displays/tDisplayDriver.cpp
+++ b/src/drivers/displays/tDisplayDriver.cpp
@@ -47,9 +47,16 @@ void tDisplay_AlternateScreenState(void)
   digitalWrite(TFT_BL, !screen_state);
 }
 
-void tDisplay_AlternateRotation(void)
+int tDisplay_AlternateRotation(void)
 {
-  tft.getRotation() == 1 ? tft.setRotation(3) : tft.setRotation(1);
+  int screen_rotation = tft.getRotation() == 1 ? 3 : 1;
+  tft.setRotation(screen_rotation);
+  return screen_rotation; 
+}
+
+void tDisplay_SetRotation(int rotation)
+{
+  tft.setRotation(rotation);
 }
 
 void tDisplay_MinerScreen(unsigned long mElapsed)
@@ -269,6 +276,7 @@ DisplayDriver tDisplayDriver = {
     tDisplay_Init,
     tDisplay_AlternateScreenState,
     tDisplay_AlternateRotation,
+    tDisplay_SetRotation,
     tDisplay_LoadingScreen,
     tDisplay_SetupScreen,
     tDisplayCyclicScreens,

--- a/src/drivers/displays/tDisplayV1Driver.cpp
+++ b/src/drivers/displays/tDisplayV1Driver.cpp
@@ -43,9 +43,16 @@ void tDisplay_AlternateScreenState(void)
   digitalWrite(TFT_BL, !screen_state);
 }
 
-void tDisplay_AlternateRotation(void)
+int tDisplay_AlternateRotation(void)
 {
-  tft.getRotation() == 1 ? tft.setRotation(3) : tft.setRotation(1);
+  int screen_rotation = tft.getRotation() == 1 ? 3 : 1;
+  tft.setRotation(screen_rotation);
+  return screen_rotation;
+}
+
+void tDisplay_SetRotation(int rotation)
+{
+  tft.setRotation(rotation);
 }
 
 void tDisplay_MinerScreen(unsigned long mElapsed)
@@ -260,6 +267,7 @@ DisplayDriver tDisplayV1Driver = {
     tDisplay_Init,
     tDisplay_AlternateScreenState,
     tDisplay_AlternateRotation,
+    tDisplay_SetRotation,
     tDisplay_LoadingScreen,
     tDisplay_SetupScreen,
     tDisplayCyclicScreens,

--- a/src/drivers/displays/t_qtDisplayDriver.cpp
+++ b/src/drivers/displays/t_qtDisplayDriver.cpp
@@ -45,7 +45,7 @@ void t_qtDisplay_AlternateScreenState(void)
 
 int t_qtDisplay_AlternateRotation(void)
 {
-  int screen_rotation = tft.getRotation()+1) % 4);
+  int screen_rotation = ((tft.getRotation()+1) % 4);
   tft.setRotation(screen_rotation);
   return screen_rotation;
 }
@@ -175,7 +175,7 @@ DisplayDriver t_qtDisplayDriver = {
     t_qtDisplay_Init,
     t_qtDisplay_AlternateScreenState,
     t_qtDisplay_AlternateRotation,
-    t_qtDisplayy_SetRotation,
+    t_qtDisplay_SetRotation,
     t_qtDisplay_LoadingScreen,
     t_qtDisplay_SetupScreen,
     t_qtDisplayCyclicScreens,

--- a/src/drivers/displays/t_qtDisplayDriver.cpp
+++ b/src/drivers/displays/t_qtDisplayDriver.cpp
@@ -43,9 +43,16 @@ void t_qtDisplay_AlternateScreenState(void)
   digitalWrite(TFT_BL, !screen_state);
 }
 
-void t_qtDisplay_AlternateRotation(void)
+int t_qtDisplay_AlternateRotation(void)
 {
-  tft.setRotation((tft.getRotation()+1) % 4);
+  int screen_rotation = tft.getRotation()+1) % 4);
+  tft.setRotation(screen_rotation);
+  return screen_rotation;
+}
+
+void t_qtDisplay_SetRotation(int rotation)
+{
+  tft.setRotation(rotation);
 }
 
 void t_qtDisplay_MinerScreen(unsigned long mElapsed)
@@ -168,6 +175,7 @@ DisplayDriver t_qtDisplayDriver = {
     t_qtDisplay_Init,
     t_qtDisplay_AlternateScreenState,
     t_qtDisplay_AlternateRotation,
+    t_qtDisplayy_SetRotation,
     t_qtDisplay_LoadingScreen,
     t_qtDisplay_SetupScreen,
     t_qtDisplayCyclicScreens,

--- a/src/drivers/storage/nvMemory.cpp
+++ b/src/drivers/storage/nvMemory.cpp
@@ -36,6 +36,7 @@ bool nvMemory::saveConfig(TSettings* Settings)
         json[JSON_SPIFFS_KEY_TIMEZONE] = Settings->Timezone;
         json[JSON_SPIFFS_KEY_STATS2NV] = Settings->saveStats;
         json[JSON_SPIFFS_KEY_SCREENOR] = Settings->screenOrientation;
+        json[JSON_SPIFFS_KEY_SCREENCY] = Settings->currentCyclicScreen;
 
         // Open config file
         File configFile = SPIFFS.open(JSON_CONFIG_FILE, "w");
@@ -100,6 +101,8 @@ bool nvMemory::loadConfig(TSettings* Settings)
                         Settings->saveStats = json[JSON_SPIFFS_KEY_STATS2NV].as<bool>();
                     if (json.containsKey(JSON_SPIFFS_KEY_SCREENOR))
                         Settings->screenOrientation = json[JSON_SPIFFS_KEY_SCREENOR].as<int>();    
+                    if (json.containsKey(JSON_SPIFFS_KEY_SCREENCY))
+                        Settings->currentCyclicScreen = json[JSON_SPIFFS_KEY_SCREENCY].as<int>();    
                     return true;
                 }
                 else

--- a/src/drivers/storage/nvMemory.cpp
+++ b/src/drivers/storage/nvMemory.cpp
@@ -35,6 +35,7 @@ bool nvMemory::saveConfig(TSettings* Settings)
         json[JSON_SPIFFS_KEY_WALLETID] = Settings->BtcWallet;
         json[JSON_SPIFFS_KEY_TIMEZONE] = Settings->Timezone;
         json[JSON_SPIFFS_KEY_STATS2NV] = Settings->saveStats;
+        json[JSON_SPIFFS_KEY_SCREENOR] = Settings->screenOrientation;
 
         // Open config file
         File configFile = SPIFFS.open(JSON_CONFIG_FILE, "w");
@@ -97,6 +98,8 @@ bool nvMemory::loadConfig(TSettings* Settings)
                         Settings->Timezone = json[JSON_SPIFFS_KEY_TIMEZONE].as<int>();
                     if (json.containsKey(JSON_SPIFFS_KEY_STATS2NV))
                         Settings->saveStats = json[JSON_SPIFFS_KEY_STATS2NV].as<bool>();
+                    if (json.containsKey(JSON_SPIFFS_KEY_SCREENOR))
+                        Settings->screenOrientation = json[JSON_SPIFFS_KEY_SCREENOR].as<int>();    
                     return true;
                 }
                 else

--- a/src/drivers/storage/storage.h
+++ b/src/drivers/storage/storage.h
@@ -35,6 +35,7 @@
 #define JSON_SPIFFS_KEY_WALLETID	"btcString"
 #define JSON_SPIFFS_KEY_TIMEZONE	"gmtZone"
 #define JSON_SPIFFS_KEY_STATS2NV	"saveStatsToNVS"
+#define JSON_SPIFFS_KEY_SCREENOR	"screenOrientation"
 
 // settings
 struct TSettings
@@ -47,6 +48,7 @@ struct TSettings
 	int PoolPort{ DEFAULT_POOLPORT };
 	int Timezone{ DEFAULT_TIMEZONE };
 	bool saveStats{ DEFAULT_SAVESTATS };
+	int screenOrientation;
 };
 
 #endif // _STORAGE_H_

--- a/src/drivers/storage/storage.h
+++ b/src/drivers/storage/storage.h
@@ -36,6 +36,8 @@
 #define JSON_SPIFFS_KEY_TIMEZONE	"gmtZone"
 #define JSON_SPIFFS_KEY_STATS2NV	"saveStatsToNVS"
 #define JSON_SPIFFS_KEY_SCREENOR	"screenOrientation"
+#define JSON_SPIFFS_KEY_SCREENCY	"currentCyclicScreen"
+
 
 // settings
 struct TSettings
@@ -49,6 +51,8 @@ struct TSettings
 	int Timezone{ DEFAULT_TIMEZONE };
 	bool saveStats{ DEFAULT_SAVESTATS };
 	int screenOrientation;
+	int screenState;
+	int currentCyclicScreen;
 };
 
 #endif // _STORAGE_H_

--- a/src/mining.cpp
+++ b/src/mining.cpp
@@ -407,7 +407,7 @@ void runMonitor(void *name)
 
   unsigned long mLastCheck = 0;
 
-  resetToFirstScreen();
+  //resetToFirstScreen();
 
   unsigned long frame = 0;
 


### PR DESCRIPTION
Hello,
I'm taking liberty to submit to your review and consideration the following pull request.
I have a few boards running this little gem of software but some are not running all the time. Hence I thought it could have been useful to restore the latest orientation and screen "cycle" selection. Could only test it on T-Display and QT Pro.

Thanks for your great work, de verdad me gusta un monton!