### PR TITLE
Add support for the ESP32-2432S024 board

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Every time an stratum job notification is received miner update its current work
 - LILYGO T-Display S3 AMOLED ([Aliexpress link\*](https://s.click.aliexpress.com/e/_DmOIK6j))
 - LILYGO T-Dongle S3 ([Aliexpress link\*](https://s.click.aliexpress.com/e/_DmQCPyj))
 - ESP32-2432S028R 2,8" ([Aliexpress link\*](https://s.click.aliexpress.com/e/_DdXkvLv) / Dev support: @nitroxgas / ⚡jadeddonald78@walletofsatoshi.com)
+- ESP32-2432S024 2,4" ([Aliexpress link](https://www.aliexpress.us/item/3256806115246299.html), [Board 
+Info](https://github.com/NoosaHydro/2.4inch_ESP32-2432S024))
 - ESP32-cam ([Board Info](https://lastminuteengineers.com/getting-started-with-esp32-cam/) / Dev support: @elmo128)
 - M5-StampS3 ([Aliexpress link\*](https://s.click.aliexpress.com/e/_DevABY3) / Dev support: @gyengus)
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,7 +11,7 @@
 [platformio]
 globallib_dir = lib
 
-default_envs = M5Stick-C, esp32cam, ESP32-2432S028R, ESP32_2432S028_2USB, NerminerV2, Lilygo-T-Embed, ESP32-devKitv1, NerminerV2-S3-DONGLE, NerminerV2-S3-AMOLED, NerminerV2-T-QT, NerdminerV2-T-Display_V1, ESP32-2432S028R, M5-StampS3, ESP32-S3-devKitv1, ESP32-S3-mini-wemos, ESP32-S3-mini-weact, ESP32-C3-devKitmv1, ESP32-C3-super-mini
+default_envs = M5Stick-C, esp32cam, ESP32-2432S028R, ESP32-2432S028-2USB, NerminerV2, Lilygo-T-Embed, ESP32-devKitv1, NerminerV2-S3-DONGLE, NerminerV2-S3-AMOLED, NerminerV2-T-QT, NerdminerV2-T-Display_V1, ESP32-2432S028R, M5-StampS3, ESP32-S3-devKitv1, ESP32-S3-mini-wemos, ESP32-S3-mini-weact, ESP32-C3-devKitmv1, ESP32-C3-super-mini
 
 
 [env:M5Stick-C]
@@ -408,11 +408,10 @@ lib_deps =
 
  ;--------------------------------------------------------------------
 
-; This env is just for another type of the popular ESP32_2432S028 which need different settings than others
-; like TFT inversion
-; and different gamma settings
+; This env is just for another type of the popular ESP32_2432S028 which need
+; different settings than others like TFT inversion and different gamma settings
 
-[env:ESP32_2432S028_2USB]
+[env:ESP32-2432S028-2USB]
 platform = espressif32
 board = esp32dev
 framework = arduino
@@ -422,7 +421,7 @@ upload_speed = 921600
 board_build.partitions = huge_app.csv
 build_flags = 
 	;-DDEBUG_MEMORY=1
-	-D ESP32_2432S028_2USB=1
+	-DESP32_2432S028_2USB=1
 	-DTFT_INVERSION_ON
 	-DUSER_SETUP_LOADED=1
 	-DILI9341_2_DRIVER=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,7 +11,7 @@
 [platformio]
 globallib_dir = lib
 
-default_envs = M5Stick-C, esp32cam, ESP32-2432S028R, ESP32-2432S028-2USB, NerminerV2, Lilygo-T-Embed, ESP32-devKitv1, NerminerV2-S3-DONGLE, NerminerV2-S3-AMOLED, NerminerV2-T-QT, NerdminerV2-T-Display_V1, ESP32-2432S028R, M5-StampS3, ESP32-S3-devKitv1, ESP32-S3-mini-wemos, ESP32-S3-mini-weact, ESP32-C3-devKitmv1, ESP32-C3-super-mini
+default_envs = M5Stick-C, esp32cam, ESP32-2432S028R, ESP32-2432S028-2USB, ESP32-2432S024, NerminerV2, Lilygo-T-Embed, ESP32-devKitv1, NerminerV2-S3-DONGLE, NerminerV2-S3-AMOLED, NerminerV2-T-QT, NerdminerV2-T-Display_V1, ESP32-2432S028R, M5-StampS3, ESP32-S3-devKitv1, ESP32-S3-mini-wemos, ESP32-S3-mini-weact, ESP32-C3-devKitmv1, ESP32-C3-super-mini
 
 
 [env:M5Stick-C]
@@ -406,7 +406,7 @@ lib_deps =
 	mathertel/OneButton @ ^2.0.3
 	arduino-libraries/NTPClient
 
- ;--------------------------------------------------------------------
+;--------------------------------------------------------------------
 
 ; This env is just for another type of the popular ESP32_2432S028 which need
 ; different settings than others like TFT inversion and different gamma settings
@@ -479,6 +479,54 @@ build_flags =
 	-DTFT_DC=2
 	-DTFT_RST=12
 	-DTFT_BL=21
+	-DETOUCH_CS=33
+	-DTOUCH_CLK=25
+	-DTOUCH_MISO=39
+	-DTOUCH_MOSI=32
+	-DTOUCH_IRQ=36
+	-DLOAD_GLCD=1
+	-DLOAD_FONT2=1
+	-DLOAD_GFXFF=1
+	-DSMOOTH_FONT=1
+	-DSPI_FREQUENCY=55000000
+	-DSPI_READ_FREQUENCY=20000000
+	-DSPI_TOUCH_FREQUENCY=2500000
+lib_deps = 
+	https://github.com/takkaO/OpenFontRender
+	bblanchon/ArduinoJson@^6.21.2
+	https://github.com/tzapu/WiFiManager.git#v2.0.16-rc.2
+	mathertel/OneButton @ ^2.0.3
+	arduino-libraries/NTPClient
+	bodmer/TFT_eSPI @ ^2.5.31
+	https://github.com/achillhasler/TFT_eTouch
+
+;--------------------------------------------------------------------
+
+; Yet another variant of the ESP32-2432S028 board ("Cheap Yellow Display").
+; It has the backlight on pin 27 instead of 21.
+
+[env:ESP32-2432S024]
+platform = espressif32
+board = esp32dev
+framework = arduino
+monitor_speed = 115200
+upload_speed = 921600
+;build_type = debug
+board_build.partitions = huge_app.csv
+build_flags = 
+	;-DDEBUG_MEMORY=1
+	-DESP32_2432S024=1	
+	-DUSER_SETUP_LOADED=1
+	-DILI9341_2_DRIVER=1
+	-DTFT_WIDTH=240
+	-DTFT_HEIGHT=320
+	-DTFT_BACKLIGHT_ON=HIGH
+	-DTFT_MOSI=13
+	-DTFT_SCLK=14
+	-DTFT_CS=15
+	-DTFT_DC=2
+	-DTFT_RST=12
+	-DTFT_BL=27
 	-DETOUCH_CS=33
 	-DTOUCH_CLK=25
 	-DTOUCH_MISO=39

--- a/src/drivers/devices/device.h
+++ b/src/drivers/devices/device.h
@@ -15,9 +15,7 @@
 #include "lilygoS3Dongle.h"
 #elif defined(LILYGO_S3_T_EMBED)
 #include "lilygoS3TEmbed.h"
-#elif defined(ESP32_2432S028R)
-#include "esp322432s028r.h"
-#elif defined(ESP32_2432S028_2USB) // For another type of ESP32_2432S028 version with 2 USB connectors
+#elif defined(ESP32_2432S028R) || defined(ESP32_2432S028_2USB) || defined(ESP32_2432S024)
 #include "esp322432s028r.h"
 #elif defined(NERMINER_T_QT)
 #include "lilygoT_QT.h"

--- a/src/drivers/displays/display.cpp
+++ b/src/drivers/displays/display.cpp
@@ -20,11 +20,7 @@ DisplayDriver *currentDisplayDriver = &amoledDisplayDriver;
 DisplayDriver *currentDisplayDriver = &dongleDisplayDriver;
 #endif
 
-#ifdef ESP32_2432S028R
-DisplayDriver *currentDisplayDriver = &esp32_2432S028RDriver;
-#endif
-
-#ifdef ESP32_2432S028_2USB
+#if defined(ESP32_2432S028R) || defined(ESP32_2432S028_2USB) || defined(ESP32_2432S024)
 DisplayDriver *currentDisplayDriver = &esp32_2432S028RDriver;
 #endif
 
@@ -39,7 +35,6 @@ DisplayDriver *currentDisplayDriver = &tDisplayV1Driver;
 #ifdef M5STICKC_DISPLAY
 DisplayDriver *currentDisplayDriver = &m5stickCDriver;
 #endif
-
 
 // Initialize the display
 void initDisplay()

--- a/src/drivers/displays/esp23_2432s028r.cpp
+++ b/src/drivers/displays/esp23_2432s028r.cpp
@@ -1,6 +1,6 @@
 #include "displayDriver.h"
 
-#if defined ESP32_2432S028R || ESP32_2432S028_2USB
+#if defined(ESP32_2432S028R) || defined(ESP32_2432S028_2USB) || defined(ESP32_2432S024)
 
 #include <TFT_eSPI.h>
 #include <TFT_eTouch.h>


### PR DESCRIPTION
This PR adds support for the ESP32-2432S024, which is another variant of the ESP32-2432S028 board. There is no big difference. The only thing I could see until now is that the backlight is connected to pin 27 instead of 21. More changes might be added in the future