### PR TITLE
Fix hours-to-seconds conversion in save intervals

### DIFF
--- a/src/mining.cpp
+++ b/src/mining.cpp
@@ -43,7 +43,7 @@ monitor_data mMonitor;
 bool isMinerSuscribed = false;
 unsigned long mLastTXtoPool = millis();
 
-int saveIntervals[7] = {5 * 60, 15 * 60, 30 * 60, 1 * 360, 3 * 360, 6 * 360, 12 * 360};
+int saveIntervals[7] = {5 * 60, 15 * 60, 30 * 60, 1 * 3600, 3 * 3600, 6 * 3600, 12 * 3600};
 int saveIntervalsSize = sizeof(saveIntervals)/sizeof(saveIntervals[0]);
 int currentIntervalIndex = 0;
 


### PR DESCRIPTION
The save intervals are meant to increase from 5 minutes up to 12 hours. However, there was a bug in the conversion from hours to seconds that resulted in wrong intervals (final save interval was 72 minutes). This commit fixes that issue.
