### PR TITLE
fixed wm password_text_box parameter error (and not appearing)

### DIFF
--- a/src/wManager.cpp
+++ b/src/wManager.cpp
@@ -135,6 +135,9 @@ void init_WifiManager()
     WiFiManagerParameter port_text_box_num("Poolport", "Pool port", convertedValue, 7);
 
     // Text box (String) - 80 characters maximum
+    WiFiManagerParameter password_text_box("Poolpassword", "Pool password (Optional)", Settings.PoolPassword, 80);
+
+    // Text box (String) - 80 characters maximum
     WiFiManagerParameter addr_text_box("btcAddress", "Your BTC address", Settings.BtcWallet, 80);
 
   // Text box (Number) - 2 characters maximum
@@ -150,8 +153,6 @@ void init_WifiManager()
     strcat(checkboxParams, " checked");
   }
   WiFiManagerParameter save_stats_to_nvs("SaveStatsToNVS", "Track Uptime, Best Diff, Total Hashes in device Flash memory. (Experimental)", "T", 2, checkboxParams, WFM_LABEL_AFTER);
-  // Text box (String) - 80 characters maximum
-  WiFiManagerParameter password_text_box("Poolpassword - Optionl", "Pool password", Settings.PoolPassword, 80);
 
   // Add all defined parameters
   wm.addParameter(&pool_text_box);


### PR DESCRIPTION
WiFiManager was reporting `*wm:[ERROR] parameter IDs can only contain alpha numeric chars` for the `password_text_box` in the serial console. 

```
NerdMiner v2 starting......
SPIFS: Mounting File System...
SPIFS: Mounted
SPIFS: No config file available!
*wm:[ERROR] parameter IDs can only contain alpha numeric chars 
AllDone: 
*wm:StartAP with SSID:  NerdMinerAP
...
```

NOTE: password_text_box was not getting displayed!

The parameter ID was being created as `Poolpassword - Optionl` which contains the `-`.

After fixing this the password text box is displayed.

![Screenshot_20240314-104633](https://github.com/BitMaker-hub/NerdMiner_v2/assets/8507802/5f71a523-2e24-4ba8-8bf8-18edfc6f6a37)
