### PR TITLE
Update platformio.ini to fix TTGO-T-Display build

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -464,14 +464,17 @@ monitor_filters =
 	esp32_exception_decoder
 	time
 	log2file
-board_build.arduino.memory_type = qio_opi
+# Commenting out 'board_build.arduino.memory_type' fixes missing 'sdkconfig.h' errors:
+;board_build.arduino.memory_type = qio_opi
 monitor_speed = 115200
 upload_speed = 115200
 # 2 x 4.5MB app, 6.875MB SPIFFS
 board_build.partitions = huge_app.csv
 build_flags = 
 	;-D DEBUG_MINING=1
-	-D TDISPLAY=1
+  	# Switching from 'TDISPLAY' to 'NERDMINER_T_DISPLAY_V1' fixes font related compile errors
+	;-D TDISPLAY=1
+	-D NERDMINER_T_DISPLAY_V1=1
 lib_deps = 
 	https://github.com/takkaO/OpenFontRender
 	bblanchon/ArduinoJson@^6.21.2


### PR DESCRIPTION
Hi. 
This fixes the TTGO-T-Display environment by addressing compile/build errors related to missing 'sdkconfig.h' and font type/definition issues. This only affects [env:TTGO-T-Display] 
Cheers.