### PR TITLE
fix: miner screen size for ttgo 1.14

### DIFF
--- a/src/drivers/displays/tDisplayV1Driver.cpp
+++ b/src/drivers/displays/tDisplayV1Driver.cpp
@@ -67,14 +67,12 @@ void tDisplay_MinerScreen(unsigned long mElapsed)
   render.rdrawString(data.currentHashRate.c_str(), 96, 90, TFT_BLACK);
   // Total hashes
   render.setFontSize(13);
-  render.rdrawString(data.totalMHashes.c_str(), 200, 112, TFT_BLACK);
+  render.rdrawString(data.totalMHashes.c_str(), 200, 106, TFT_BLACK);
   // Block templates
-  render.setFontSize(13);
   render.drawString(data.templates.c_str(), 140, 15, 0xDEDB);
   // Best diff
   render.drawString(data.bestDiff.c_str(), 140, 38, 0xDEDB);
   // 32Bit shares
-  render.setFontSize(13);
   render.drawString(data.completedShares.c_str(), 140, 60, 0xDEDB);
   // Hores
   render.setFontSize(9);

--- a/src/media/images_240_135.h
+++ b/src/media/images_240_135.h
@@ -142,7 +142,7 @@ const unsigned short setupModeScreen[0xFD20] PROGMEM  = {
 
 // Icon width and height
 const uint16_t MinerWidth = 240;
-const uint16_t MinerHeight = 128;
+const uint16_t MinerHeight = 135;
 
 
 const unsigned short MinerScreen[0x7800] PROGMEM  = {


### PR DESCRIPTION
Fixed small issues on 1.14 display when use miner screen:

- Removed space on bottom.
- Aligned total hash info.

<img src='https://github.com/BitMaker-hub/NerdMiner_v2/assets/5353685/d744b7c7-5fef-408f-801b-c37293505ff8' width=350/>

