### PR TITLE
add platform to allow calling workers metrics api

### DIFF
--- a/src/drivers/devices/esp322432s028r.h
+++ b/src/drivers/devices/esp322432s028r.h
@@ -32,4 +32,7 @@
 #define SDSPI_MOSI  23
 #define SDSPI_MISO  19
 
+// calls api to retrieve worker metrics
+#define SCREEN_WORKERS_ENABLE (1)
+
 #endif

--- a/src/drivers/devices/lilygoT_HMI.h
+++ b/src/drivers/devices/lilygoT_HMI.h
@@ -37,10 +37,15 @@
 #define TOUCH_ENABLE (1)
 #define SDMMC_1BIT_FIX (1)
 #define SD_FREQUENCY (20000)
+
+// calls api to retrieve worker metrics
+#define SCREEN_WORKERS_ENABLE (1)
+// retrieve current btc fees data
+#define SCREEN_FEES_ENABLE (1)
+
 #ifndef TFT_BL
 // XXX - defined in User_Setups/Setup207_LilyGo_T_HMI.h:37
 #define TFT_BL        (38) // LED back-light
 #endif
-
 
 #endif

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -364,7 +364,7 @@ pool_data getPoolData(void){
           String btcWallet = Settings.BtcWallet;
           // Serial.println(btcWallet);
           if (btcWallet.indexOf(".")>0) btcWallet = btcWallet.substring(0,btcWallet.indexOf("."));
-#ifdef NERDMINER_T_HMI
+#ifdef SCREEN_WORKERS_ENABLE
           Serial.println("Pool API : " + poolAPIUrl+btcWallet);
           http.begin(poolAPIUrl+btcWallet);
 #else


### PR DESCRIPTION
To address issue raised in https://github.com/BitMaker-hub/NerdMiner_v2/issues/484

#### Worker metrics
Add the following define to the platform specific header to enable API to retrieve worker metrics
```
// calls api to retrieve worker metrics
#define SCREEN_WORKERS_ENABLE (1)
```

![I11111MG_20240123_221837](https://github.com/BitMaker-hub/NerdMiner_v2/assets/122713120/ed3629b3-3379-4d61-babe-e89ade9e9e50)

#### Fees Data (Proposed and requires code reorg utilize)
Add the following define to the platform specific header to future use of fees data
```
// retrieve current btc fees data
#define SCREEN_FEES_ENABLE (1)
```

![22222IMG_20240123_215510](https://github.com/BitMaker-hub/NerdMiner_v2/assets/122713120/cdeeef38-c07f-48e1-a42e-c9c2c5b6a51b)

####  Current purposed mining sites
proposed title,   entered path,    api endpoint
"public-pool.io","public-pool.io", "https://public-pool.io:40557/api/client/"
"nerdminers.org", "nerdminers.org", "https://pool.nerdminers.org/users/"
"sethforprivacy.com", "pool.sethforprivacy.com", "https://pool.sethforprivacy.com/api/client/"
"public-pool.io","http://" + Umbrel or Start9 ip address + ":2019/api/client/"  // Local instance of public-pool.io on Umbrel or Start9
 Note: vkbit pool was removed from mem worker API discovery because https://github.com/BitMaker-hub/NerdMiner_v2/pull/410

#### To test for API availability:
```
$ curl https://public-pool.io:40557/api/client/
{"workersCount":0,"workers":[]}          
```

See this [video>>](https://youtu.be/El1wv85a0DI) for how it works with lower screen and battery
