### PR TITLE
read and manage battery voltage 

### DIFF
--- a/src/BatteryMonitor.cpp
+++ b/src/BatteryMonitor.cpp
@@ -1,0 +1,124 @@
+
+#include "drivers/devices/device.h"
+
+#ifdef BATTERY_MONITOR_ENABLE
+#include <iostream>
+#include <xpt2046.h>
+#include <driver/adc.h>
+#include <esp_adc_cal.h> // For calibration structure
+#include "BatteryMonitor.h"
+
+// is it 4.2 or 4.4 volts?
+const float BATTERY_MAX = 4.2;
+const float BATTERY_MIN = 3.3;
+const int VOLTAGE_MIN = 3300;
+const int VOLTAGE_MAX = 4350;
+
+BatteryMonitor::BatteryMonitor() {}
+
+void BatteryMonitor::setup() {
+    pinMode(PWR_EN_PIN, OUTPUT);
+    digitalWrite(PWR_EN_PIN, HIGH);
+    delay(100);
+    
+    // Configure ADC
+    adc1_config_width(ADC_WIDTH_BIT_12);
+    adc1_config_channel_atten(ADC1_CHANNEL_0, ADC_ATTEN_DB_0);
+
+    // Calibrate ADC
+    esp_adc_cal_value_t val_type = esp_adc_cal_characterize(ADC_UNIT_1, ADC_ATTEN_DB_11, ADC_WIDTH_BIT_12, 1100, &adc_chars);
+    if (val_type == ESP_ADC_CAL_VAL_EFUSE_TP) {
+        Serial.println("ADC characterized using Two Point values stored in eFuse");
+    } else if (val_type == ESP_ADC_CAL_VAL_EFUSE_VREF) {
+        Serial.println("ADC characterized using eFuse Vref");
+    } else {
+        Serial.println("ADC characterized using default Vref");
+    }
+    printEspAdcCalCharacteristics();
+}
+
+float BatteryMonitor::readBatteryVoltage() {
+    uint32_t voltage = batteryAdcVoltageRead() * 2;
+    return static_cast<float>(voltage) / 1000.0;
+}
+
+void BatteryMonitor::printBatteryVoltage() {
+    float voltage = readBatteryVoltage();
+    Serial.print("Battery voltage: ");
+    Serial.println(voltage, 3);
+}
+
+float BatteryMonitor::calculateBatteryLevel() {
+    
+    if ((mThrottle == 0) || (millis() - mThrottle > UpdateThresholdMin * 60 * 1000)) {
+        float voltage = readBatteryVoltage();
+        Serial.print("Battery voltage: ");
+        Serial.println(voltage, 3);
+        batteryLevel = ((voltage * 1000) - VOLTAGE_MIN) * 100 / (VOLTAGE_MAX - VOLTAGE_MIN);
+        Serial.print("Battery Level: ");
+        Serial.println(batteryLevel, 2);
+        mThrottle = millis();
+    }
+    return batteryLevel < 100 ? batteryLevel : 100.0f;
+}
+
+void BatteryMonitor::monitorBattery() {
+    float batteryLevel = calculateBatteryLevel();
+}
+
+uint32_t BatteryMonitor::batteryAdcVoltageRead() {
+    return esp_adc_cal_raw_to_voltage(analogRead(BAT_ADC_PIN), &adc_chars);
+}
+
+// Function to print the structure contents to the ESP32 console
+void BatteryMonitor::printEspAdcCalCharacteristics() {
+    // Begin serial communication if needed (make sure Serial.begin() is called in setup)
+    Serial.println("ADC Calibration Characteristics:");
+
+    // Print ADC number
+    Serial.print("ADC Unit: ");
+    Serial.println(static_cast<int>(adc_chars.adc_num));
+
+    // Print ADC attenuation
+    Serial.print("ADC Attenuation: ");
+    Serial.println(static_cast<int>(adc_chars.atten));
+
+    // Print ADC bit width
+    Serial.print("ADC Bit Width: ");
+    Serial.println(static_cast<int>(adc_chars.bit_width));
+
+    // Print coefficients
+    Serial.print("Coefficient A: ");
+    Serial.println(adc_chars.coeff_a);
+
+    Serial.print("Coefficient B: ");
+    Serial.println(adc_chars.coeff_b);
+
+    // Print Vref
+    Serial.print("Vref: ");
+    Serial.println(adc_chars.vref);
+
+    // Print Low Curve
+    if (adc_chars.low_curve != nullptr) {
+        Serial.print("Low Curve Pointer: ");
+        Serial.println(reinterpret_cast<uintptr_t>(adc_chars.low_curve), HEX);  // Print as hex
+    } else {
+        Serial.println("Low Curve: Not available");
+    }
+
+    // Print High Curve
+    if (adc_chars.high_curve != nullptr) {
+        Serial.print("High Curve Pointer: ");
+        Serial.println(reinterpret_cast<uintptr_t>(adc_chars.high_curve), HEX);  // Print as hex
+    } else {
+        Serial.println("High Curve: Not available");
+    }
+
+    // Print Version
+    Serial.print("Version: ");
+    Serial.println(static_cast<int>(adc_chars.version));
+}
+
+
+
+#endif

--- a/src/BatteryMonitor.cpp
+++ b/src/BatteryMonitor.cpp
@@ -12,7 +12,7 @@
 const float BATTERY_MAX = 4.2;
 const float BATTERY_MIN = 3.3;
 const int VOLTAGE_MIN = 3300;
-const int VOLTAGE_MAX = 4350;
+const int VOLTAGE_MAX = 4200;
 
 BatteryMonitor::BatteryMonitor() {}
 

--- a/src/BatteryMonitor.h
+++ b/src/BatteryMonitor.h
@@ -1,0 +1,32 @@
+#include "drivers/devices/device.h"
+#ifndef BATTERY_MONITOR_H
+#define BATTERY_MONITOR_H
+
+#ifdef BATTERY_MONITOR_ENABLE
+#include <driver/adc.h>
+#include <esp_adc_cal.h>
+
+
+class BatteryMonitor {
+
+public:
+    BatteryMonitor();
+
+    void setup();
+    float readBatteryVoltage();
+    void printBatteryVoltage();
+    float calcBatteryLevel();
+    float calculateBatteryLevel();
+    void monitorBattery();
+
+private:
+    unsigned long mThrottle = 0;
+    int UpdateThresholdMin = 1;
+    float batteryLevel = 0.0f;
+    esp_adc_cal_characteristics_t adc_chars;
+    uint32_t batteryAdcVoltageRead();
+    void printEspAdcCalCharacteristics();
+};
+
+#endif
+#endif // BATTERY_MONITOR_H

--- a/src/NerdMinerV2.ino.cpp
+++ b/src/NerdMinerV2.ino.cpp
@@ -15,9 +15,11 @@
 #include "drivers/storage/SDCard.h"
 #include "timeconst.h"
 
-#ifdef TOUCH_ENABLE
+//  #ifdef TOUCH_ENABLE
 #include "TouchHandler.h"
-#endif
+// #endif
+
+#include "BatteryMonitor.h"
 
 //3 seconds WDT
 #define WDT_TIMEOUT 3
@@ -34,6 +36,10 @@
 
 #ifdef TOUCH_ENABLE
 extern TouchHandler touchHandler;
+#endif
+
+#ifdef BATTERY_MONITOR_ENABLE
+extern BatteryMonitor batteryMonitor;
 #endif
 
 extern monitor_data mMonitor;
@@ -175,6 +181,9 @@ void loop() {
 
 #ifdef TOUCH_ENABLE
   touchHandler.isTouched();
+#endif
+#ifdef BATTERY_MONITOR_ENABLE
+  batteryMonitor.monitorBattery();
 #endif
   wifiManagerProcess(); // avoid delays() in loop when non-blocking and other long running code
 

--- a/src/drivers/devices/lilygoT_HMI.h
+++ b/src/drivers/devices/lilygoT_HMI.h
@@ -37,6 +37,9 @@
 #define TOUCH_ENABLE (1)
 #define SDMMC_1BIT_FIX (1)
 #define SD_FREQUENCY (20000)
+
+#define BATTERY_MONITOR_ENABLE (1)
+
 #ifndef TFT_BL
 // XXX - defined in User_Setups/Setup207_LilyGo_T_HMI.h:37
 #define TFT_BL        (38) // LED back-light

--- a/src/drivers/displays/t_hmiDisplayDriver.cpp
+++ b/src/drivers/displays/t_hmiDisplayDriver.cpp
@@ -99,6 +99,20 @@ void t_hmiDisplay_AlternateRotation(void)
    tft.getRotation() == 1 ? tft.setRotation(3) : tft.setRotation(1);
 }
 
+#ifdef BATTERY_MONITOR_ENABLE
+void printBatteryLevel()
+{
+  // Print Battery Level
+  float batteryLevel = batteryMonitor.calculateBatteryLevel();
+
+  // Convert float to string for rendering
+  char batteryLevelStr[10];  // Adjust the size based on how many decimal places you need
+  sprintf(batteryLevelStr, "%.0f", batteryLevel);  // Format float to string with 2 decimal places
+
+  render.setFontSize(12);
+  render.drawString(batteryLevelStr, 10/*210*/, 1,  TFT_WHITE/*0xDEDB*/);  // Use formatted string
+}
+#endif
 
 void printPoolData()
 {
@@ -185,15 +199,7 @@ void t_hmiDisplay_MinerScreen(unsigned long mElapsed)
   render.drawString(data.valids.c_str(), 285, 56, 0xDEDB);
 
 #ifdef BATTERY_MONITOR_ENABLE
-  // Print Battery Level
-  float batteryLevel = batteryMonitor.calculateBatteryLevel();
-
-  // Convert float to string for rendering
-  char batteryLevelStr[10];  // Adjust the size based on how many decimal places you need
-  sprintf(batteryLevelStr, "%.0f", batteryLevel);  // Format float to string with 2 decimal places
-
-  render.setFontSize(10);
-  render.rdrawString(batteryLevelStr, 210, 1,  0xDEDB);  // Use formatted string
+  printBatteryLevel();
 #endif
 
   // Print Temp
@@ -249,6 +255,9 @@ void t_hmiDisplay_ClockScreen(unsigned long mElapsed)
   background.setTextColor(0xDEDB, TFT_BLACK);
 
   background.drawString(data.currentTime.c_str(), 130, 50, GFXFF);
+#ifdef BATTERY_MONITOR_ENABLE
+  printBatteryLevel();
+#endif
   if (lowerScreen == 1)
     printMemPoolFees(mElapsed);
   else
@@ -311,7 +320,9 @@ void t_hmiDisplay_GlobalHashScreen(unsigned long mElapsed)
   background.setTextDatum(MC_DATUM);
   background.setTextColor(TFT_BLACK);
   background.drawString(data.remainingBlocks.c_str(), 72, 159, FONT2);
-
+#ifdef BATTERY_MONITOR_ENABLE
+  printBatteryLevel();
+#endif
   if (lowerScreen == 1)
     printMemPoolFees(mElapsed);
   else
@@ -356,6 +367,9 @@ void t_hmiDisplay_BTCprice(unsigned long mElapsed)
   background.setTextSize(1);
   background.setTextColor(0xDEDB, TFT_BLACK);
   background.drawString(data.btcPrice.c_str(), 300, 58, GFXFF);
+#ifdef BATTERY_MONITOR_ENABLE
+  printBatteryLevel();
+#endif
   if (lowerScreen == 1)
     printPoolData();
   else

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -8,6 +8,7 @@
 #include "utils.h"
 #include "monitor.h"
 #include "drivers/storage/storage.h"
+#include "BatteryMonitor.h"
 
 extern uint32_t templates;
 extern uint32_t hashes;
@@ -35,6 +36,9 @@ global_data gData;
 pool_data pData;
 String poolAPIUrl;
 
+#ifdef BATTERY_MONITOR_ENABLE
+extern BatteryMonitor batteryMonitor;
+#endif
 
 void setup_monitor(void){
     /******** TIME ZONE SETTING *****/
@@ -49,6 +53,9 @@ void setup_monitor(void){
 #ifdef NERDMINER_T_HMI
     poolAPIUrl = getPoolAPIUrl();
     Serial.println("poolAPIUrl: " + poolAPIUrl);
+#endif
+#ifdef BATTERY_MONITOR_ENABLE
+    batteryMonitor.setup();
 #endif
 }
 


### PR DESCRIPTION
Created and integrated a BatteryMonitor class formalizing what was used to test with T-HMI for general use.  
1/ not really satisfied with the normalization of battery level based on voltage.   charges to 100% unplug drops to 70%
2/ prototype temporary battery level on upper left for testing adding this to any screen layout.
```
#ifdef BATTERY_MONITOR_ENABLE
void printBatteryLevel()
{
  // Print Battery Level
  float batteryLevel = batteryMonitor.calculateBatteryLevel();

  // Convert float to string for rendering
  char batteryLevelStr[10];  // Adjust the size based on how many decimal places you need
  sprintf(batteryLevelStr, "%.0f", batteryLevel);  // Format float to string with 2 decimal places

  render.setFontSize(12);
  render.drawString(batteryLevelStr, 10/*210*/, 1,  TFT_WHITE/*0xDEDB*/);  // Use formatted string
}
#endif

```
3/ need help with background bmp graphics adjustments

![xxx](https://github.com/user-attachments/assets/94c1e69b-3847-4fc9-b590-144758a45761)
See this [video>>](https://youtu.be/El1wv85a0DI) for how it works with lower screen and battery

https://github.com/BitMaker-hub/NerdMiner_v2/issues/465