### PR TITLE
Change the BTC/USDT ticker to Binance

### DIFF
--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -164,7 +164,12 @@ String getBTCprice(void){
 
             DynamicJsonDocument doc(1024);
             deserializeJson(doc, payload);
-            if (doc.containsKey("last_trade_price")) bitcoin_price = doc["last_trade_price"];
+            
+            if (doc.containsKey("price")) {
+                String priceStr = doc["price"];
+                float priceFloat = priceStr.toFloat();
+                bitcoin_price = (int)priceFloat; // Truncate the decimal part by casting to int
+            }
 
             doc.clear();
 

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -12,8 +12,8 @@
 //Time update period
 #define UPDATE_PERIOD_h   5
 
-//API BTC price (Update to USDT cus it's more liquidity and flow price updade)   
-#define getBTCAPI "https://api.blockchain.com/v3/exchange/tickers/BTC-USDT"
+//API BTC price (BTC/USDT hanged on the same amount for days, reverting to BTC-USD)   
+#define getBTCAPI "https://api.binance.com/api/v3/ticker/price?symbol=BTCUSDT"
 #define UPDATE_BTC_min   1
 
 //API Block height


### PR DESCRIPTION
I installed v1.7.0 on my T-Display S3 and saw that the BTC/USDT ticker didn't update its price for a day. I want to see a more up to date price.

I changed the ticker to https://api.binance.com.