### PR TITLE
ESP32_2432S028_2USB missing invert screen config option, extra screen heap

### DIFF
--- a/src/NerdMinerV2.ino.cpp
+++ b/src/NerdMinerV2.ino.cpp
@@ -127,7 +127,7 @@ void setup()
 
   /******** CREATE STRATUM TASK *****/
   sprintf(name, "(%s)", "Stratum");
- #ifdef ESP32_2432S028R
+ #if defined(ESP32_2432S028R) || defined(ESP32_2432S028_2USB)
  // Free a little bit of the heap to the screen
   BaseType_t res2 = xTaskCreatePinnedToCore(runStratumWorker, "Stratum", 13500, (void*)name, 3, NULL,1);
  #else

--- a/src/wManager.cpp
+++ b/src/wManager.cpp
@@ -179,7 +179,7 @@ void init_WifiManager()
   wm.addParameter(&time_text_box_num);
   wm.addParameter(&features_html);
   wm.addParameter(&save_stats_to_nvs);
-  #ifdef ESP32_2432S028R
+  #if defined(ESP32_2432S028R) || defined(ESP32_2432S028_2USB)
   char checkboxParams2[24] = "type=\"checkbox\"";
   if (Settings.invertColors)
   {
@@ -208,7 +208,7 @@ void init_WifiManager()
             Settings.Timezone = atoi(time_text_box_num.getValue());
             //Serial.println(save_stats_to_nvs.getValue());
             Settings.saveStats = (strncmp(save_stats_to_nvs.getValue(), "T", 1) == 0);
-            #ifdef ESP32_2432S028R
+            #if defined(ESP32_2432S028R) || defined(ESP32_2432S028_2USB)
                 Settings.invertColors = (strncmp(invertColors.getValue(), "T", 1) == 0);
             #endif
             nvMem.saveConfig(&Settings);
@@ -238,7 +238,7 @@ void init_WifiManager()
                 Settings.Timezone = atoi(time_text_box_num.getValue());
                 // Serial.println(save_stats_to_nvs.getValue());
                 Settings.saveStats = (strncmp(save_stats_to_nvs.getValue(), "T", 1) == 0);
-                #ifdef ESP32_2432S028R
+                #if defined(ESP32_2432S028R) || defined(ESP32_2432S028_2USB)
                 Settings.invertColors = (strncmp(invertColors.getValue(), "T", 1) == 0);
                 #endif
                 nvMem.saveConfig(&Settings);
@@ -284,7 +284,7 @@ void init_WifiManager()
         Serial.print("TimeZone fromUTC: ");
         Serial.println(Settings.Timezone);
 
-        #ifdef ESP32_2432S028R
+        #if defined(ESP32_2432S028R) || defined(ESP32_2432S028_2USB)
         Settings.invertColors = (strncmp(invertColors.getValue(), "T", 1) == 0);
         Serial.print("Invert Colors: ");
         Serial.println(Settings.invertColors);        
@@ -296,7 +296,7 @@ void init_WifiManager()
     if (shouldSaveConfig)
     {
         nvMem.saveConfig(&Settings);
-        #ifdef ESP32_2432S028R
+        #if defined(ESP32_2432S028R) || defined(ESP32_2432S028_2USB)
          if (Settings.invertColors) ESP.restart();                
         #endif
     }


### PR DESCRIPTION
This PR fixes the missing invert screen option in the configuration menu on the CYD ESP32_2432S028_2USB variant.
Also adding the missing check in the NerdMinerV2.ino.cpp for more free heap to the screen, as in the ESP32_2432S028R variant already had.
I have a few of these "2432S028" labeled, 2 connectors CYD boards from recent Ali purchases, and all of them required the inverted screen setting for the correct display.