### PR TITLE
CYD ESP32_2432S028 Brightness option in config

### DIFF
--- a/src/drivers/storage/SDCard.cpp
+++ b/src/drivers/storage/SDCard.cpp
@@ -128,6 +128,11 @@ bool SDCard::loadConfigFile(TSettings* Settings)
                     } else {
                         Settings->invertColors = false;
                     }
+                    if (json.containsKey(JSON_KEY_BRIGHTNESS)) {
+                        Settings->Brightness = json[JSON_KEY_BRIGHTNESS].as<int>();
+                    } else {
+                        Settings->Brightness = 250;
+                    }
                     // Serial.printf("Carteira Lida SD:%s\n", Settings.BtcWallet);       
                     Serial.printf("Carteira Lida SDs:%s\n", Settings->BtcWallet);                       
                     return true;

--- a/src/drivers/storage/nvMemory.cpp
+++ b/src/drivers/storage/nvMemory.cpp
@@ -36,6 +36,7 @@ bool nvMemory::saveConfig(TSettings* Settings)
         json[JSON_SPIFFS_KEY_TIMEZONE] = Settings->Timezone;
         json[JSON_SPIFFS_KEY_STATS2NV] = Settings->saveStats;
         json[JSON_SPIFFS_KEY_INVCOLOR] = Settings->invertColors;
+        json[JSON_SPIFFS_KEY_BRIGHTNESS] = Settings->Brightness;
 
         // Open config file
         File configFile = SPIFFS.open(JSON_CONFIG_FILE, "w");
@@ -102,6 +103,11 @@ bool nvMemory::loadConfig(TSettings* Settings)
                         Settings->invertColors = json[JSON_SPIFFS_KEY_INVCOLOR].as<bool>();
                     } else {
                         Settings->invertColors = false;
+                    }
+                    if (json.containsKey(JSON_SPIFFS_KEY_BRIGHTNESS)) {
+                        Settings->Brightness = json[JSON_SPIFFS_KEY_BRIGHTNESS].as<int>();
+                    } else {
+                        Settings->Brightness = 250;
                     }
                     return true;
                 }

--- a/src/drivers/storage/storage.h
+++ b/src/drivers/storage/storage.h
@@ -19,6 +19,7 @@
 #define DEFAULT_TIMEZONE	2
 #define DEFAULT_SAVESTATS	false
 #define DEFAULT_INVERTCOLORS	false
+#define DEFAULT_BRIGHTNESS	250
 
 // JSON config files
 #define JSON_CONFIG_FILE	"/config.json"
@@ -33,6 +34,7 @@
 #define JSON_KEY_TIMEZONE	"Timezone"
 #define JSON_KEY_STATS2NV	"SaveStats"
 #define JSON_KEY_INVCOLOR	"invertColors"
+#define JSON_KEY_BRIGHTNESS	"Brightness"
 
 // JSON config file SPIFFS (different for backward compatibility with existing devices)
 #define JSON_SPIFFS_KEY_POOLURL		"poolString"
@@ -42,6 +44,7 @@
 #define JSON_SPIFFS_KEY_TIMEZONE	"gmtZone"
 #define JSON_SPIFFS_KEY_STATS2NV	"saveStatsToNVS"
 #define JSON_SPIFFS_KEY_INVCOLOR	"invertColors"
+#define JSON_SPIFFS_KEY_BRIGHTNESS	"Brightness"
 
 // settings
 struct TSettings
@@ -55,6 +58,7 @@ struct TSettings
 	int Timezone{ DEFAULT_TIMEZONE };
 	bool saveStats{ DEFAULT_SAVESTATS };
 	bool invertColors{ DEFAULT_INVERTCOLORS };
+	int Brightness{ DEFAULT_BRIGHTNESS };
 };
 
 #endif // _STORAGE_H_

--- a/src/wManager.cpp
+++ b/src/wManager.cpp
@@ -188,6 +188,13 @@ void init_WifiManager()
   WiFiManagerParameter invertColors("inverColors", "Invert Display Colors (if the colors looks weird)", "T", 2, checkboxParams2, WFM_LABEL_AFTER);
   wm.addParameter(&invertColors);
   #endif
+  #if defined(ESP32_2432S028R) || defined(ESP32_2432S028_2USB)
+    char brightnessConvValue[2];
+    sprintf(brightnessConvValue, "%d", Settings.Brightness);
+    // Text box (Number) - 3 characters maximum
+    WiFiManagerParameter brightness_text_box_num("Brightness", "Screen backlight Duty Cycle (0-255)", brightnessConvValue, 3);
+    wm.addParameter(&brightness_text_box_num);
+  #endif
 
     Serial.println("AllDone: ");
     if (forceConfig)    
@@ -210,6 +217,9 @@ void init_WifiManager()
             Settings.saveStats = (strncmp(save_stats_to_nvs.getValue(), "T", 1) == 0);
             #ifdef ESP32_2432S028R
                 Settings.invertColors = (strncmp(invertColors.getValue(), "T", 1) == 0);
+            #endif
+            #if defined(ESP32_2432S028R) || defined(ESP32_2432S028_2USB)
+                Settings.Brightness = atoi(brightness_text_box_num.getValue());
             #endif
             nvMem.saveConfig(&Settings);
             delay(3*SECOND_MS);
@@ -240,6 +250,9 @@ void init_WifiManager()
                 Settings.saveStats = (strncmp(save_stats_to_nvs.getValue(), "T", 1) == 0);
                 #ifdef ESP32_2432S028R
                 Settings.invertColors = (strncmp(invertColors.getValue(), "T", 1) == 0);
+                #endif
+                #if defined(ESP32_2432S028R) || defined(ESP32_2432S028_2USB)
+                Settings.Brightness = atoi(brightness_text_box_num.getValue());
                 #endif
                 nvMem.saveConfig(&Settings);
                 vTaskDelay(2000 / portTICK_PERIOD_MS);      
@@ -290,6 +303,12 @@ void init_WifiManager()
         Serial.println(Settings.invertColors);        
         #endif
 
+        #if defined(ESP32_2432S028R) || defined(ESP32_2432S028_2USB)
+        Settings.Brightness = atoi(brightness_text_box_num.getValue());
+        Serial.print("Brightness: ");
+        Serial.println(Settings.Brightness);
+        #endif
+
     }
 
     // Save the custom parameters to FS
@@ -298,6 +317,9 @@ void init_WifiManager()
         nvMem.saveConfig(&Settings);
         #ifdef ESP32_2432S028R
          if (Settings.invertColors) ESP.restart();                
+        #endif
+        #if defined(ESP32_2432S028R) || defined(ESP32_2432S028_2USB)
+        if (Settings.Brightness != 250) ESP.restart();
         #endif
     }
 }


### PR DESCRIPTION
This PR adds a Brightness option in the Configuration Portal and this entry enabled and used for the ESP32_2432S028 and ESP32_2432S028R devices.
The TFT backlight brightness is manipulated using the `ledcWrite(LEDC_Channel, LEDC_Duty);` Arduino-ESP32 LEDC API.

I only have these boards at hand to test it, therefore I only added support for the brightness control in the `esp23_2432s028r.cpp` display driver. But it should be straightforward to extend to other boards where the screen backlight is connected to the esp32 and it can be driven with PWM signal.

Additionally added a small touch zone on these devices for the top right corner, around the "gray status label".
Touching this part, the backlight turns off completely. Touching it again reverts to the set up brightness value.

With the currently set up 8bit duty cycle resolution (can be changed), we can choose from 0-255 for the backlight.
I found, that setting it to 32 it is still fairly bright for indoor use, but the device power consumption lowered by one third.