### PR TITLE
feat: support ESP32-C3 0.42 OLED

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -327,6 +327,35 @@ lib_ignore =
 
 ;--------------------------------------------------------------------
 
+[env:ESP32-C3-042-OLED]
+platform = espressif32@6.6.0
+board = adafruit_qtpy_esp32c3
+framework = arduino
+monitor_filters = 
+	esp32_exception_decoder
+	time
+	log2file
+monitor_speed = 115200
+upload_speed = 115200
+board_build.partitions = huge_app.csv
+build_flags = 
+	-D ARDUINO_USB_MODE=1
+	-D ARDUINO_USB_CDC_ON_BOOT=1
+	-D ESP32_C3_042_OLED
+	-D PIN_BUTTON_1=9
+lib_deps = 
+	https://github.com/takkaO/OpenFontRender#v1.2
+	bblanchon/ArduinoJson@^6.21.5
+	https://github.com/tzapu/WiFiManager.git#v2.0.17
+	mathertel/oneButton@^2.6.1
+	arduino-libraries/NTPClient@^3.2.1
+	olikraus/U8g2@^2.34.17
+lib_ignore = 
+	TFT_eSPI
+	HANSOLOminerv2
+
+;--------------------------------------------------------------------
+
 [env:ESP32-S3-devKitv1]
 platform = espressif32@6.6.0
 board = esp32-s3-devkitc-1

--- a/src/drivers/devices/device.h
+++ b/src/drivers/devices/device.h
@@ -7,6 +7,8 @@
 #include "M5Stick-C.h"
 #elif defined(DEVKITV1)
 #include "esp32DevKit.h"
+#elif defined(ESP32_C3_042_OLED)
+#include "esp32C3042OLED.h"
 #elif defined(TDISPLAY)
 #include "lilygoS3TDisplay.h"
 #elif defined(NERDMINER_S3_AMOLED)

--- a/src/drivers/devices/esp32C3042OLED.h
+++ b/src/drivers/devices/esp32C3042OLED.h
@@ -1,0 +1,14 @@
+#ifndef _ESP32_C3_042_OLED_H
+#define _ESP32_C3_042_OLED_H
+
+#ifndef SDA_PIN
+#define SDA_PIN 5
+#endif
+
+#ifndef SCL_PIN
+#define SCL_PIN 6
+#endif
+
+#define OLED_042_DISPLAY
+
+#endif

--- a/src/drivers/displays/display.cpp
+++ b/src/drivers/displays/display.cpp
@@ -16,6 +16,10 @@ DisplayDriver *currentDisplayDriver = &wt32DisplayDriver;
 DisplayDriver *currentDisplayDriver = &ledDisplayDriver;
 #endif
 
+#ifdef OLED_042_DISPLAY
+DisplayDriver *currentDisplayDriver = &oled042DisplayDriver;
+#endif
+
 #ifdef T_DISPLAY
 DisplayDriver *currentDisplayDriver = &tDisplayDriver;
 #endif

--- a/src/drivers/displays/displayDriver.h
+++ b/src/drivers/displays/displayDriver.h
@@ -32,6 +32,7 @@ extern DisplayDriver m5stackDisplayDriver;
 extern DisplayDriver wt32DisplayDriver;
 extern DisplayDriver noDisplayDriver;
 extern DisplayDriver ledDisplayDriver;
+extern DisplayDriver oled042DisplayDriver;
 extern DisplayDriver tDisplayDriver;
 extern DisplayDriver amoledDisplayDriver;
 extern DisplayDriver dongleDisplayDriver;

--- a/src/drivers/displays/oled042DisplayDriver.cpp
+++ b/src/drivers/displays/oled042DisplayDriver.cpp
@@ -1,0 +1,156 @@
+
+#include "displayDriver.h"
+
+#ifdef OLED_042_DISPLAY
+
+#include <U8g2lib.h>
+#include "monitor.h"
+
+#ifdef U8X8_HAVE_HW_SPI
+#include <SPI.h>
+#endif
+#ifdef U8X8_HAVE_HW_I2C
+#include <Wire.h>
+#endif
+
+static uint8_t btc_icon[] = {
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+  0x00, 0xF0, 0x03, 0x00, 0x00, 0xFE, 0x1F, 0x00, 0x00, 0xFF, 0x3F, 0x00, 
+  0x80, 0xFF, 0x7F, 0x00, 0xC0, 0xFF, 0xFF, 0x00, 0xE0, 0x3F, 0xFF, 0x01, 
+  0xF0, 0x3F, 0xFF, 0x03, 0xF0, 0x0F, 0xFC, 0x03, 0xF0, 0x0F, 0xF8, 0x03, 
+  0xF8, 0xCF, 0xF9, 0x07, 0xF8, 0xCF, 0xF9, 0x07, 0xF8, 0x0F, 0xFC, 0x07, 
+  0xF8, 0x0F, 0xF8, 0x07, 0xF8, 0xCF, 0xF9, 0x07, 0xF8, 0xCF, 0xF9, 0x07, 
+  0xF0, 0x0F, 0xF8, 0x03, 0xF0, 0x0F, 0xFC, 0x03, 0xF0, 0x3F, 0xFF, 0x03, 
+  0xE0, 0x3F, 0xFF, 0x01, 0xC0, 0xFF, 0xFF, 0x00, 0x80, 0xFF, 0x7F, 0x00, 
+  0x00, 0xFF, 0x3F, 0x00, 0x00, 0xFE, 0x1F, 0x00, 0x00, 0xF0, 0x03, 0x00, 
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+};
+
+static uint8_t setup_icon[] = {
+  0x00, 0x00, 0x00, 0x00, 0x00, 0xE0, 0x01, 0x00, 0x00, 0xE0, 0x01, 0x00, 
+  0x00, 0xF0, 0x03, 0x00, 0xC0, 0xF0, 0xC3, 0x00, 0xE0, 0xF9, 0xE3, 0x01, 
+  0xF0, 0xFF, 0xFF, 0x03, 0xF0, 0xFF, 0xFF, 0x03, 0xE0, 0xFF, 0xFF, 0x01, 
+  0xC0, 0xFF, 0xFF, 0x00, 0xC0, 0xFF, 0xFF, 0x00, 0xE0, 0x1F, 0xFE, 0x00, 
+  0xF8, 0x0F, 0xFC, 0x07, 0xFE, 0x07, 0xF8, 0x1F, 0xFE, 0x07, 0xF8, 0x1F, 
+  0xFE, 0x07, 0xF8, 0x1F, 0xFE, 0x07, 0xF8, 0x1F, 0xF8, 0x0F, 0xFC, 0x07, 
+  0xE0, 0x1F, 0xFE, 0x00, 0xC0, 0xFF, 0xFF, 0x00, 0xC0, 0xFF, 0xFF, 0x00, 
+  0xE0, 0xFF, 0xFF, 0x01, 0xF0, 0xFF, 0xFF, 0x03, 0xF0, 0xFF, 0xFF, 0x03, 
+  0xE0, 0xF9, 0xE3, 0x01, 0xC0, 0xF0, 0xC3, 0x00, 0x00, 0xF0, 0x03, 0x00, 
+  0x00, 0xE0, 0x01, 0x00, 0x00, 0xE0, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 
+};
+
+U8G2_SSD1306_72X40_ER_F_HW_I2C u8g2(U8G2_R0, /* reset=*/ U8X8_PIN_NONE);
+
+void clearScreen(void) {
+    u8g2.clearBuffer();
+    u8g2.sendBuffer();
+}
+
+void serialPrint(unsigned long mElapsed) {
+  mining_data data = getMiningData(mElapsed);
+
+  // Print hashrate to serial
+  Serial.printf(">>> Completed %s share(s), %s Khashes, avg. hashrate %s KH/s\n",
+                data.completedShares.c_str(), data.totalKHashes.c_str(), data.currentHashRate.c_str());
+
+  // Print extended data to serial for no display devices
+  Serial.printf(">>> Valid blocks: %s\n", data.valids.c_str());
+  Serial.printf(">>> Block templates: %s\n", data.templates.c_str());
+  Serial.printf(">>> Best difficulty: %s\n", data.bestDiff.c_str());
+  Serial.printf(">>> 32Bit shares: %s\n", data.completedShares.c_str());
+  Serial.printf(">>> Temperature: %s\n", data.temp.c_str());
+  Serial.printf(">>> Total MHashes: %s\n", data.totalMHashes.c_str());
+  Serial.printf(">>> Time mining: %s\n", data.timeMining.c_str());
+}
+
+void oledDisplay_Init(void)
+{
+  Serial.println("OLED 0.42 display driver initialized");
+  Wire.begin(SDA_PIN, SCL_PIN);
+  u8g2.begin();
+  u8g2.clear();
+  u8g2.setFlipMode(1);
+  clearScreen();
+}
+
+void oledDisplay_AlternateScreenState(void)
+{
+  Serial.println("Switching display state");
+}
+
+void oledDisplay_AlternateRotation(void)
+{
+}
+
+void oledDisplay_Screen1(unsigned long mElapsed)
+{
+  mining_data data = getMiningData(mElapsed);
+
+  u8g2.clearBuffer();
+  u8g2.setFont(u8g2_font_helvB18_tf);
+  u8g2.drawStr(0, 20, data.currentHashRate.c_str());
+  u8g2.setFont(u8g2_font_helvB08_tf);
+  u8g2.drawStr(45, 36, "KH/s");
+  u8g2.sendBuffer();
+
+  serialPrint(mElapsed);
+}
+
+void oledDisplay_Screen2(unsigned long mElapsed)
+{
+  mining_data data = getMiningData(mElapsed);
+  char temp[8];
+  sprintf(temp, "%s°c", data.temp.c_str());
+
+  u8g2.clearBuffer(); 
+  u8g2.setFont(u8g2_font_helvB18_tf);
+  u8g2.drawUTF8(0, 20, temp);
+  u8g2.sendBuffer();
+
+  serialPrint(mElapsed);
+}
+
+void oledDisplay_LoadingScreen(void)
+{
+  Serial.println("Initializing...");
+  u8g2.clearBuffer();
+  u8g2.drawXBMP(20,5,30,30, btc_icon);
+  u8g2.sendBuffer();
+}
+
+void oledDisplay_SetupScreen(void)
+{
+  Serial.println("Setup...");
+  u8g2.clearBuffer();
+  u8g2.drawXBMP(20,0,30,30, setup_icon);
+  u8g2.setFont(u8g2_font_helvB08_tf);
+  u8g2.drawUTF8(20, 38, "Setup");
+  u8g2.sendBuffer();
+}
+
+void oledDisplay_DoLedStuff(unsigned long frame)
+{
+}
+
+void oledDisplay_AnimateCurrentScreen(unsigned long frame)
+{
+}
+
+CyclicScreenFunction oledDisplayCyclicScreens[] = {oledDisplay_Screen1, oledDisplay_Screen2};
+
+DisplayDriver oled042DisplayDriver = {
+    oledDisplay_Init,
+    oledDisplay_AlternateScreenState,
+    oledDisplay_AlternateRotation,
+    oledDisplay_LoadingScreen,
+    oledDisplay_SetupScreen,
+    oledDisplayCyclicScreens,
+    oledDisplay_AnimateCurrentScreen,
+    oledDisplay_DoLedStuff,
+    SCREENS_ARRAY_SIZE(oledDisplayCyclicScreens),
+    0,
+    0,
+    0,
+};
+
+#endif


### PR DESCRIPTION
This PR add new device support [ESP32-C3 0.42 OLED](https://github.com/01Space/ESP32-C3-0.42LCD) board.

![IMG_8970](https://github.com/user-attachments/assets/11ae7fed-3e49-4483-a830-15b983cc18f4)


