### PR TITLE
worker-api: add new supported pools

### DIFF
--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -339,6 +339,8 @@ String getPoolAPIUrl(void) {
                 case 3333:
                     if (Settings.PoolAddress == "pool.sethforprivacy.com")
                         poolAPIUrl = "https://pool.sethforprivacy.com/api/client/";
+                    if (Settings.PoolAddress == "pool.solomining.de")
+                        poolAPIUrl = "https://pool.solomining.de/api/client/";
                     // Add more cases for other addresses with port 3333 if needed
                     break;
                 case 2018:

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -331,7 +331,7 @@ String getPoolAPIUrl(void) {
         poolAPIUrl = "https://public-pool.io:40557/api/client/";
     } 
     else {
-        if (Settings.PoolAddress == "nerdminers.org") {
+        if (Settings.PoolAddress == "pool.nerdminers.org") {
             poolAPIUrl = "https://pool.nerdminers.org/users/";
         }
         else {


### PR DESCRIPTION
@DarKOrange75

pool.nerdminers.org matching failed defaulting back to pool-miner.io

The documentation describes the worker api but a 404 is the result.

https://pool.nerdminers.org/index.html
To see individual user statistics, append the BTC address to this URL like this:
https://pool.nerdminers.org/users/bc1q28kkr5hk4gnqe3evma6runjrd2pvqyp8fpwfzu

> 
> WiFi connected IP address: 192.168.1.111 PoolString: pool.nerdminers.org portNumber: 3333 poolPassword: x btcString: xxx.test TimeZone fromUTC: 1 Invert Colors: 1 Brightness: 250
> 
> Initiating tasks... [MONITOR] started
> 
> [WORKER] Started. Running (Stratum) on core 1 Client not connected, trying to connect... [MINER] 0 Started runMiner Task! [MINER] 1 Started runMiner Task! TimeClient setup done poolAPIUrl: https://public-pool.io:40557/api/client/Resolved DNS and save ip (first time) got: 144.91.83.152
> 
> CONNECTED - Current ip: 192.168.1.111 [WORKER] ==> Mining subscribe Sending : {"id": 1, "method": "mining.subscribe", "params": ["NerdMinerV2/V1.7.0"]}
> 
> TimeClient NTPupdateTime Pool API : https://public-pool.io:40557/api/client/xxx Receiving: {"result":[[["mining.notify","67e5f117"]],"5421e067",8],"id":1,"error":null} sub_details: 67e5f117 extranonce1: 5421e067 extranonce2_size: 8 [WORKER] ==> Autorize work Sending : {"params": ["xxx.test", "x"], "id": 2, "method": "mining.authorize"}
> 
> Sending : {"id": 3, "method": "mining.suggest_difficulty", "params": [0.0001]} Received message from pool Receiving: {"params":[0.00050000000000000001],"id":null,"method":"mining.set_difficulty"} Parsing Method [SET DIFFICULTY] difficulty: 0.000500000000 Received message from pool

