### PR TITLE
Add NerdMiner v2 support for Espressif ESP32-S3-DevKitC-1-N32R8

### DIFF
--- a/boards/esp32-s3-devkitc1-n32r8.json
+++ b/boards/esp32-s3-devkitc1-n32r8.json
@@ -1,0 +1,55 @@
+{
+  "build": {
+    "arduino": {
+      "partitions": "default.csv",
+      "memory_type": "opi_opi"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_ESP32S3_DEV",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1",
+      "-DBOARD_HAS_PSRAM"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "opi",
+    "psram_type": "opi",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "esp32s3"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "platforms": [
+    "espressif32"
+  ],
+  "name": "Espressif ESP32-S3-DevKitC-1-N32R8V (32 MB Flash Octal, 8 MB PSRAM Octal)",
+  "upload": {
+    "flash_size": "32MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 33554432,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/user-guide-devkitc-1.html",
+  "vendor": "Espressif"
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -996,3 +996,40 @@ lib_ignore =
 	SPI
 	HANSOLOminerv2
 
+
+ ;-----------------------------------------------------------------------
+ [env:esp32-s3-devkitc1-n32r8]
+platform                   = espressif32@6.6.0
+board                      = esp32-s3-devkitc1-n32r8
+framework                  = arduino
+
+extra_scripts              = pre:auto_firmware_version.py
+
+monitor_speed              = 115200
+upload_speed               = 115200
+monitor_filters            = esp32_exception_decoder, time, log2file
+
+; ---- Partitions ----
+board_build.partitions     = huge_app.csv
+board_build.filesystem     = LittleFS
+
+; ---- Build Flags ----
+build_flags = 
+    -D BOARD_HAS_PSRAM
+    -D ARDUINO_USB_MODE=1          ; ← nur lassen, wenn Dein USB-Port direkt am ESP32-S3 hängt
+    -D ARDUINO_USB_CDC_ON_BOOT=1   ;   sonst beide Flags löschen
+    -D ESP32RGB=1
+    -D RGB_LED_PIN=38 
+    -D RGB_LED_ORDER=BRG
+    ;-D DEBUG_MINING=1
+
+; ---- Libraries ----
+lib_deps = 
+    https://github.com/takkaO/OpenFontRender#v1.2
+    bblanchon/ArduinoJson@^6.21.5
+    https://github.com/tzapu/WiFiManager.git#v2.0.17
+    mathertel/oneButton@^2.6.1
+    arduino-libraries/NTPClient@^3.2.1
+    fastled/FastLED@3.7.8
+
+lib_ignore = TFT_eSPI, HANSOLOminerv2

--- a/platformio.ini
+++ b/platformio.ini
@@ -998,7 +998,7 @@ lib_ignore =
 
 
  ;-----------------------------------------------------------------------
- [env:esp32-s3-devkitc1-n32r8]
+[env:esp32-s3-devkitc1-n32r8]
 platform                   = espressif32@6.6.0
 board                      = esp32-s3-devkitc1-n32r8
 framework                  = arduino

--- a/platformio.ini
+++ b/platformio.ini
@@ -500,6 +500,39 @@ lib_ignore =
 	TFT_eSPI
 	HANSOLOminerv2
 
+;-----------------------------------------------------------------------
+[env:esp32-s3-devkitc1-n32r8]
+platform                   = espressif32@6.6.0
+board                      = esp32-s3-devkitc1-n32r8
+framework                  = arduino
+
+extra_scripts              = pre:auto_firmware_version.py
+
+monitor_speed              = 115200
+upload_speed               = 115200
+monitor_filters            = esp32_exception_decoder, time, log2file
+
+board_build.partitions     = huge_app.csv
+board_build.filesystem     = LittleFS
+
+build_flags = 
+    -D BOARD_HAS_PSRAM
+    -D ARDUINO_USB_MODE=1        
+    -D ARDUINO_USB_CDC_ON_BOOT=1   
+    -D ESP32RGB=1
+    -D RGB_LED_PIN=38
+    ;-D DEBUG_MINING=1
+
+lib_deps = 
+    https://github.com/takkaO/OpenFontRender#v1.2
+    bblanchon/ArduinoJson@^6.21.5
+    https://github.com/tzapu/WiFiManager.git#v2.0.17
+    mathertel/oneButton@^2.6.1
+    arduino-libraries/NTPClient@^3.2.1
+    fastled/FastLED@3.7.8
+
+lib_ignore = TFT_eSPI, HANSOLOminerv2
+
 ;--------------------------------------------------------------------
 
 [env:NerdminerV2]
@@ -997,39 +1030,4 @@ lib_ignore =
 	HANSOLOminerv2
 
 
- ;-----------------------------------------------------------------------
-[env:esp32-s3-devkitc1-n32r8]
-platform                   = espressif32@6.6.0
-board                      = esp32-s3-devkitc1-n32r8
-framework                  = arduino
 
-extra_scripts              = pre:auto_firmware_version.py
-
-monitor_speed              = 115200
-upload_speed               = 115200
-monitor_filters            = esp32_exception_decoder, time, log2file
-
-; ---- Partitions ----
-board_build.partitions     = huge_app.csv
-board_build.filesystem     = LittleFS
-
-; ---- Build Flags ----
-build_flags = 
-    -D BOARD_HAS_PSRAM
-    -D ARDUINO_USB_MODE=1        
-    -D ARDUINO_USB_CDC_ON_BOOT=1   
-    -D ESP32RGB=1
-    -D RGB_LED_PIN=38 
-    -D RGB_LED_ORDER=BRG
-    ;-D DEBUG_MINING=1
-
-; ---- Libraries ----
-lib_deps = 
-    https://github.com/takkaO/OpenFontRender#v1.2
-    bblanchon/ArduinoJson@^6.21.5
-    https://github.com/tzapu/WiFiManager.git#v2.0.17
-    mathertel/oneButton@^2.6.1
-    arduino-libraries/NTPClient@^3.2.1
-    fastled/FastLED@3.7.8
-
-lib_ignore = TFT_eSPI, HANSOLOminerv2

--- a/platformio.ini
+++ b/platformio.ini
@@ -1016,8 +1016,8 @@ board_build.filesystem     = LittleFS
 ; ---- Build Flags ----
 build_flags = 
     -D BOARD_HAS_PSRAM
-    -D ARDUINO_USB_MODE=1          ; ← nur lassen, wenn Dein USB-Port direkt am ESP32-S3 hängt
-    -D ARDUINO_USB_CDC_ON_BOOT=1   ;   sonst beide Flags löschen
+    -D ARDUINO_USB_MODE=1        
+    -D ARDUINO_USB_CDC_ON_BOOT=1   
     -D ESP32RGB=1
     -D RGB_LED_PIN=38 
     -D RGB_LED_ORDER=BRG


### PR DESCRIPTION
 File | Change | Purpose |
|------|--------|---------|
| `boards/esp32-s3-devkitc1-n32r8.json`*| Added | New board definition (32 MB Octal-SPI Flash, 8 MB Octal PSRAM, correct VID/PID, clocks, partitions). |
| `platformio.ini` | Added `[env:esp32-s3-devkitc1-n32r8]` profile |  |

No application code was modified; this PR simply makes the firmware compile and run out-of-the-box on the ESP32-S3-DevKitC-1-N32R8.

**Tested with**

* PlatformIO 6.6.0  
* Arduino-ESP32 v2.0.11  

Firmware flashes and runs successfully on the DevKitC-N32R8.  

