### PR TITLE
Add debugging to prerelease download step

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -61,6 +61,15 @@ jobs:
         with:
           path: ${{ github.workspace }}/
           name: firmware-files-${{ github.sha }}
+      - name: Debug - Check downloaded files
+        run: |
+          echo "=== Working directory ==="
+          pwd
+          ls -la
+          echo "=== All .bin files after download ==="
+          find . -name "*.bin" -type f
+          echo "=== firmware directory after download ==="
+          find firmware -type f 2>/dev/null || echo "No firmware directory found"
       - name: Prerelease
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
- Debug downloaded artifact contents in prerelease job
- Check if firmware files are correctly downloaded from build job
- Help identify path issues between build and release steps