### PR TITLE
Use broader file pattern to debug artifact discovery

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -79,5 +79,5 @@ jobs:
           generate_release_notes: true
           prerelease: true
           fail_on_unmatched_files: true
-          files: ${{ github.workspace }}/firmware/*/*.bin
+          files: ${{ github.workspace }}/**/*.bin
 


### PR DESCRIPTION
- Changed from firmware/*/*.bin to **/*.bin for testing
- Should find any .bin files regardless of directory structure
- Help identify if issue is path-specific or file generation