### PR TITLE
ESP32C3-CORE LuatOS board support with external flash

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,7 +11,7 @@
 [platformio]
 globallib_dir = lib
 
-default_envs =  NerdminerV2, NerdminerV2-T-HMI, wt32-sc01, wt32-sc01-plus, han_m5stack, M5Stick-C, M5Stick-C-Plus2, M5Stick-CPlus, esp32cam, ESP32-2432S028R, ESP32_2432S028_2USB, ESP32-2432S024, Lilygo-T-Embed, ESP32-devKitv1, NerdminerV2-S3-DONGLE, NerdminerV2-S3-GEEK, NerdminerV2-S3-AMOLED, NerdminerV2-S3-AMOLED-TOUCH, NerdminerV2-T-QT, NerdminerV2-T-Display_V1, TTGO-T-Display, M5-StampS3, ESP32-S3-devKitv1, ESP32-S3-mini-wemos, ESP32-S2-mini-wemos, ESP32-S3-mini-weact, ESP32-D0WD-V3-weact, ESP32-C3-super-mini, ESP32-C3-devKitmv1, ESP32-C3-042-OLED, ESP32-S3-042-OLED, ESP32-C3-spotpear, esp32-s3-devkitc1-n32r8
+default_envs =  NerdminerV2, NerdminerV2-T-HMI, wt32-sc01, wt32-sc01-plus, han_m5stack, M5Stick-C, M5Stick-C-Plus2, M5Stick-CPlus, esp32cam, ESP32-2432S028R, ESP32_2432S028_2USB, ESP32-2432S024, Lilygo-T-Embed, ESP32-devKitv1, NerdminerV2-S3-DONGLE, NerdminerV2-S3-GEEK, NerdminerV2-S3-AMOLED, NerdminerV2-S3-AMOLED-TOUCH, NerdminerV2-T-QT, NerdminerV2-T-Display_V1, TTGO-T-Display, M5-StampS3, ESP32-S3-devKitv1, ESP32-S3-mini-wemos, ESP32-S2-mini-wemos, ESP32-S3-mini-weact, ESP32-D0WD-V3-weact, ESP32-C3-super-mini, ESP32-C3-luatos-core, ESP32-C3-devKitmv1, ESP32-C3-042-OLED, ESP32-S3-042-OLED, ESP32-C3-spotpear, esp32-s3-devkitc1-n32r8
 
 ; Global configuration for all environments
 [env]
@@ -387,6 +387,40 @@ build_flags =
 	-D DEVKITV1=1
 	-D PIN_BUTTON_1=9
 	-D LED_PIN=8
+	;-D DEBUG_MINING=1
+lib_deps = 
+	https://github.com/takkaO/OpenFontRender#v1.2
+	bblanchon/ArduinoJson@^6.21.5
+	https://github.com/tzapu/WiFiManager.git#v2.0.17
+	mathertel/oneButton@^2.6.1
+	arduino-libraries/NTPClient@^3.2.1
+lib_ignore = 
+	TFT_eSPI
+	HANSOLOminerv2
+
+;--------------------------------------------------------------------
+
+[env:ESP32-C3-luatos-core]
+platform = espressif32@6.6.0
+board = seeed_xiao_esp32c3
+framework = arduino
+extra_scripts =
+    pre:auto_firmware_version.py
+    post:post_build_merge.py
+monitor_filters = 
+	esp32_exception_decoder
+	time
+	log2file
+monitor_speed = 115200
+upload_speed = 115200
+board_build.partitions = huge_app.csv
+board_build.flash_mode = dio
+build_flags = 
+	-D ARDUINO_USB_MODE=1
+	-D ARDUINO_USB_CDC_ON_BOOT=1
+	-D DEVKITV1=1
+	-D PIN_BUTTON_1=9
+	-D LED_PIN=12 ; D4 LED
 	;-D DEBUG_MINING=1
 lib_deps = 
 	https://github.com/takkaO/OpenFontRender#v1.2


### PR DESCRIPTION
Enabling board support for ESP32C3-CORE LuatOS development board: https://wiki.luatos.org/chips/esp32c3/board.html