### PR TITLE
Adding support for ESP32-C3 boards with 0.42 oled from WiseChip

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,7 +11,7 @@
 [platformio]
 globallib_dir = lib
 
-default_envs =  NerdminerV2, NerdminerV2-T-HMI, wt32-sc01, wt32-sc01-plus, han_m5stack, M5Stick-C, M5Stick-C-Plus2, M5Stick-CPlus, esp32cam, ESP32-2432S028R, ESP32_2432S028_2USB, ESP32-2432S024, Lilygo-T-Embed, ESP32-devKitv1, NerdminerV2-S3-DONGLE, NerdminerV2-S3-GEEK, NerdminerV2-S3-AMOLED, NerdminerV2-S3-AMOLED-TOUCH, NerdminerV2-T-QT, NerdminerV2-T-Display_V1, TTGO-T-Display, M5-StampS3, ESP32-S3-devKitv1, ESP32-S3-mini-wemos, ESP32-S2-mini-wemos, ESP32-S3-mini-weact, ESP32-D0WD-V3-weact, ESP32-C3-super-mini, ESP32-C3-devKitmv1, ESP32-C3-042-OLED, ESP32-S3-042-OLED, ESP32-C3-spotpear, esp32-s3-devkitc1-n32r8
+default_envs =  NerdminerV2, NerdminerV2-T-HMI, wt32-sc01, wt32-sc01-plus, han_m5stack, M5Stick-C, M5Stick-C-Plus2, M5Stick-CPlus, esp32cam, ESP32-2432S028R, ESP32_2432S028_2USB, ESP32-2432S024, Lilygo-T-Embed, ESP32-devKitv1, NerdminerV2-S3-DONGLE, NerdminerV2-S3-GEEK, NerdminerV2-S3-AMOLED, NerdminerV2-S3-AMOLED-TOUCH, NerdminerV2-T-QT, NerdminerV2-T-Display_V1, TTGO-T-Display, M5-StampS3, ESP32-S3-devKitv1, ESP32-S3-mini-wemos, ESP32-S2-mini-wemos, ESP32-S3-mini-weact, ESP32-D0WD-V3-weact, ESP32-C3-super-mini, ESP32-C3-devKitmv1, ESP32-C3-042-OLED, ESP32-C3-042-OLED-WISECHIP, ESP32-S3-042-OLED, ESP32-C3-spotpear, esp32-s3-devkitc1-n32r8
 
 ; Global configuration for all environments
 [env]
@@ -453,6 +453,39 @@ build_flags =
 	-D ARDUINO_USB_CDC_ON_BOOT=1
 	-D ESP32_C3_042_OLED
 	-D PIN_BUTTON_1=9
+lib_deps = 
+	https://github.com/takkaO/OpenFontRender#v1.2
+	bblanchon/ArduinoJson@^6.21.5
+	https://github.com/tzapu/WiFiManager.git#v2.0.17
+	mathertel/oneButton@^2.6.1
+	arduino-libraries/NTPClient@^3.2.1
+	olikraus/U8g2@^2.34.17
+lib_ignore = 
+	TFT_eSPI
+	HANSOLOminerv2
+
+;--------------------------------------------------------------------
+
+[env:ESP32-C3-042-OLED-WISECHIP]
+platform = espressif32@6.6.0
+board = esp32-c3-devkitm-1
+framework = arduino
+extra_scripts =
+    pre:auto_firmware_version.py
+    post:post_build_merge.py
+monitor_filters = 
+	esp32_exception_decoder
+	time
+	log2file
+monitor_speed = 115200
+upload_speed = 115200
+board_build.partitions = huge_app.csv
+build_flags = 
+	-D ARDUINO_USB_MODE=1
+	-D ARDUINO_USB_CDC_ON_BOOT=1
+	-D ESP32_C3_042_OLED
+	-D PIN_BUTTON_1=9
+	-D OLED_042_WISECHIP
 lib_deps = 
 	https://github.com/takkaO/OpenFontRender#v1.2
 	bblanchon/ArduinoJson@^6.21.5

--- a/src/drivers/displays/oled042DisplayDriver.cpp
+++ b/src/drivers/displays/oled042DisplayDriver.cpp
@@ -39,7 +39,11 @@ static uint8_t setup_icon[] = {
   0x00, 0xE0, 0x01, 0x00, 0x00, 0xE0, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 
 };
 
+#ifdef OLED_042_WISECHIP
+U8G2_SH1106_72X40_WISE_F_HW_I2C u8g2(U8G2_R0, /* reset=*/ U8X8_PIN_NONE);
+#else
 U8G2_SSD1306_72X40_ER_F_HW_I2C u8g2(U8G2_R0, /* reset=*/ U8X8_PIN_NONE);
+#endif
 
 void clearScreen(void) {
     u8g2.clearBuffer();


### PR DESCRIPTION
Some ESP32-C3 boards with 0.42" OLED has WiseChip oled instead of EastRising oled which has different offsets and already defined in U8g2 lib, adding support for those by adding new define.