### PR TITLE
fix: remove out-of-bounds write in merkle_root

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -321,7 +321,6 @@ miner_data calculateMiningData(mining_subscribe& mWorker, mining_job mJob){
       Serial.printf("%02x", mMiner.merkle_result[i]);
       snprintf(&merkle_root[i*2], 3, "%02x", mMiner.merkle_result[i]);
     }
-    merkle_root[65] = 0;
     Serial.println("");
 
     // calculate blockheader


### PR DESCRIPTION
Line 324 was writing to index 65 of a 65-byte array (valid indices 0-64). The snprintf loop already null-terminates correctly at index 64, so this line was redundant and caused a 1-byte buffer overflow. Fixes #771 