### PR TITLE
Add LilyGo T3 V1.6.1 board support with SSD1306

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,7 +11,7 @@
 [platformio]
 globallib_dir = lib
 
-default_envs =  NerdminerV2, NerdminerV2-T-HMI, wt32-sc01, wt32-sc01-plus, han_m5stack, M5Stick-C, M5Stick-C-Plus2, M5Stick-CPlus, esp32cam, ESP32-2432S028R, ESP32_2432S028_2USB, ESP32-2432S024, Lilygo-T-Embed, ESP32-devKitv1, NerdminerV2-S3-DONGLE, NerdminerV2-S3-GEEK, NerdminerV2-S3-AMOLED, NerdminerV2-S3-AMOLED-TOUCH, NerdminerV2-T-QT, NerdminerV2-T-Display_V1, TTGO-T-Display, M5-StampS3, ESP32-S3-devKitv1, ESP32-S3-mini-wemos, ESP32-S2-mini-wemos, ESP32-S3-mini-weact, ESP32-D0WD-V3-weact, ESP32-C3-super-mini, ESP32-C3-devKitmv1, ESP32-C3-042-OLED, ESP32-S3-042-OLED, ESP32-C3-spotpear, esp32-s3-devkitc1-n32r8
+default_envs =  LilygoT3V1, NerdminerV2, NerdminerV2-T-HMI, wt32-sc01, wt32-sc01-plus, han_m5stack, M5Stick-C, M5Stick-C-Plus2, M5Stick-CPlus, esp32cam, ESP32-2432S028R, ESP32_2432S028_2USB, ESP32-2432S024, Lilygo-T-Embed, ESP32-devKitv1, NerdminerV2-S3-DONGLE, NerdminerV2-S3-GEEK, NerdminerV2-S3-AMOLED, NerdminerV2-S3-AMOLED-TOUCH, NerdminerV2-T-QT, NerdminerV2-T-Display_V1, TTGO-T-Display, M5-StampS3, ESP32-S3-devKitv1, ESP32-S3-mini-wemos, ESP32-S2-mini-wemos, ESP32-S3-mini-weact, ESP32-D0WD-V3-weact, ESP32-C3-super-mini, ESP32-C3-devKitmv1, ESP32-C3-042-OLED, ESP32-S3-042-OLED, ESP32-C3-spotpear, esp32-s3-devkitc1-n32r8
 
 ; Global configuration for all environments
 [env]
@@ -1106,6 +1106,32 @@ lib_deps =
 	bodmer/TFT_eSPI @ ^2.5.31
 	https://github.com/achillhasler/TFT_eTouch
 lib_ignore = 
+	HANSOLOminerv2
+
+;--------------------------------------------------------------------
+
+[env:LilygoT3V1]
+platform = espressif32@6.6.0
+board = ttgo-lora32-v21
+framework = arduino
+extra_scripts =
+    pre:auto_firmware_version.py
+    post:post_build_merge.py
+monitor_speed = 115200
+upload_speed = 921600
+board_build.partitions = huge_app.csv
+build_flags =
+	-D LILYGO_T3_V1=1
+	;-D DEBUG_MINING=1
+lib_deps =
+	https://github.com/takkaO/OpenFontRender#v1.2
+	bblanchon/ArduinoJson@^6.21.5
+	https://github.com/tzapu/WiFiManager.git#v2.0.17
+	mathertel/oneButton@^2.6.1
+	arduino-libraries/NTPClient@^3.2.1
+	olikraus/U8g2@^2.34.17
+lib_ignore =
+	TFT_eSPI
 	HANSOLOminerv2
 
 ;--------------------------------------------------------------------

--- a/src/drivers/devices/device.h
+++ b/src/drivers/devices/device.h
@@ -53,6 +53,8 @@
 #include "lilygoT_HMI.h"
 #elif defined(SPOTPEAR)
 #include "spotpearKeychain.h"
+#elif defined(LILYGO_T3_V1)
+#include "lilygoT3V1.h"
 
 #else
 #error "No device defined"

--- a/src/drivers/devices/lilygoT3V1.h
+++ b/src/drivers/devices/lilygoT3V1.h
@@ -1,0 +1,12 @@
+#ifndef _LILYGO_T3_V1_H
+#define _LILYGO_T3_V1_H
+
+// LilyGo T3 V1.6.1 - SSD1306 128x64 OLED (I2C)
+#define SDA_PIN 21
+#define SCL_PIN 22
+
+#define PIN_BUTTON_1 0
+
+#define OLED_SSD1306_128X64_DISPLAY
+
+#endif

--- a/src/drivers/displays/display.cpp
+++ b/src/drivers/displays/display.cpp
@@ -64,6 +64,10 @@ DisplayDriver *currentDisplayDriver = &t_hmiDisplayDriver;
 DisplayDriver *currentDisplayDriver = &sp_kcDisplayDriver;
 #endif
 
+#ifdef OLED_SSD1306_128X64_DISPLAY
+DisplayDriver *currentDisplayDriver = &ssd1306DisplayDriver;
+#endif
+
 
 // Initialize the display
 void initDisplay()

--- a/src/drivers/displays/displayDriver.h
+++ b/src/drivers/displays/displayDriver.h
@@ -43,6 +43,7 @@ extern DisplayDriver m5stickCDriver;
 extern DisplayDriver m5stickCPlusDriver;
 extern DisplayDriver t_hmiDisplayDriver;
 extern DisplayDriver sp_kcDisplayDriver;
+extern DisplayDriver ssd1306DisplayDriver;
 
 #define SCREENS_ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 

--- a/src/drivers/displays/ssd1306DisplayDriver.cpp
+++ b/src/drivers/displays/ssd1306DisplayDriver.cpp
@@ -1,0 +1,132 @@
+
+#include "displayDriver.h"
+
+#ifdef OLED_SSD1306_128X64_DISPLAY
+
+#include <U8g2lib.h>
+#include "monitor.h"
+
+#ifdef U8X8_HAVE_HW_I2C
+#include <Wire.h>
+#endif
+
+U8G2_SSD1306_128X64_NONAME_F_HW_I2C u8g2(U8G2_R0, /* reset=*/ U8X8_PIN_NONE);
+
+void ssd1306_clearScreen(void) {
+    u8g2.clearBuffer();
+    u8g2.sendBuffer();
+}
+
+void serialPrint_ssd1306(unsigned long mElapsed) {
+  mining_data data = getMiningData(mElapsed);
+  Serial.printf(">>> Hashrate: %s KH/s | Shares: %s | Best diff: %s\n",
+                data.currentHashRate.c_str(), data.completedShares.c_str(), data.bestDiff.c_str());
+}
+
+void ssd1306Display_Init(void) {
+  Serial.println("SSD1306 128x64 display driver initialized");
+  Wire.begin(SDA_PIN, SCL_PIN);
+  u8g2.begin();
+  u8g2.clear();
+  ssd1306_clearScreen();
+}
+
+void ssd1306Display_AlternateScreenState(void) {}
+void ssd1306Display_AlternateRotation(void) {}
+
+void ssd1306Display_Screen1(unsigned long mElapsed) {
+  mining_data data = getMiningData(mElapsed);
+
+  u8g2.clearBuffer();
+
+  // Header
+  u8g2.setFont(u8g2_font_6x10_tf);
+  u8g2.drawStr(0, 10, "NERDMINER v2");
+  u8g2.drawHLine(0, 12, 128);
+
+  // Hashrate (big)
+  u8g2.setFont(u8g2_font_helvB18_tf);
+  u8g2.drawStr(0, 38, data.currentHashRate.c_str());
+  u8g2.setFont(u8g2_font_6x10_tf);
+  u8g2.drawStr(90, 38, "KH/s");
+
+  // Bottom line: shares and best diff
+  u8g2.drawHLine(0, 50, 128);
+  u8g2.setFont(u8g2_font_5x7_tf);
+  String shares = "Shares: " + data.completedShares;
+  String bestDiff = "Best: " + data.bestDiff;
+  u8g2.drawStr(0, 62, shares.c_str());
+  u8g2.drawStr(70, 62, bestDiff.c_str());
+
+  u8g2.sendBuffer();
+  serialPrint_ssd1306(mElapsed);
+}
+
+void ssd1306Display_Screen2(unsigned long mElapsed) {
+  mining_data data = getMiningData(mElapsed);
+
+  u8g2.clearBuffer();
+
+  u8g2.setFont(u8g2_font_6x10_tf);
+  u8g2.drawStr(0, 10, "MINING STATS");
+  u8g2.drawHLine(0, 12, 128);
+
+  u8g2.setFont(u8g2_font_5x7_tf);
+  String hashrate = "Hashrate: " + data.currentHashRate + " KH/s";
+  String hashes   = "Total MH: " + data.totalMHashes;
+  String uptime   = "Uptime: " + data.timeMining;
+  String temp     = "Temp: " + data.temp + " C";
+
+  u8g2.drawStr(0, 26, hashrate.c_str());
+  u8g2.drawStr(0, 36, hashes.c_str());
+  u8g2.drawStr(0, 46, uptime.c_str());
+  u8g2.drawStr(0, 56, temp.c_str());
+
+  u8g2.sendBuffer();
+  serialPrint_ssd1306(mElapsed);
+}
+
+void ssd1306Display_LoadingScreen(void) {
+  Serial.println("Loading...");
+  u8g2.clearBuffer();
+  u8g2.setFont(u8g2_font_helvB18_tf);
+  u8g2.drawStr(10, 30, "NERD");
+  u8g2.drawStr(10, 55, "MINER");
+  u8g2.sendBuffer();
+}
+
+void ssd1306Display_SetupScreen(void) {
+  Serial.println("Setup mode...");
+  u8g2.clearBuffer();
+  u8g2.setFont(u8g2_font_6x10_tf);
+  u8g2.drawStr(20, 20, "SETUP MODE");
+  u8g2.drawStr(5, 35, "Connect to WiFi:");
+  u8g2.drawStr(5, 48, "NerdMinerAP");
+  u8g2.drawStr(5, 61, "MineYourCoins");
+  u8g2.sendBuffer();
+}
+
+void ssd1306Display_DoLedStuff(unsigned long frame) {}
+void ssd1306Display_AnimateCurrentScreen(unsigned long frame) {}
+
+CyclicScreenFunction ssd1306DisplayCyclicScreens[] = {
+    ssd1306Display_Screen1,
+    ssd1306Display_Screen2
+};
+
+DisplayDriver ssd1306DisplayDriver = {
+    ssd1306Display_Init,
+    ssd1306Display_AlternateScreenState,
+    ssd1306Display_AlternateRotation,
+    ssd1306Display_LoadingScreen,
+    ssd1306Display_SetupScreen,
+    ssd1306DisplayCyclicScreens,
+    ssd1306Display_AnimateCurrentScreen,
+    ssd1306Display_DoLedStuff,
+    SCREENS_ARRAY_SIZE(ssd1306DisplayCyclicScreens),
+    0,
+    128,
+    64,
+};
+
+#endif


### PR DESCRIPTION
This PR adds support for the LilyGo T3 V1.6.1 board
which features a built-in SSD1306 128x64 OLED display connected via I2C.

Changes:
- Add new device header: src/drivers/devices/lilygoT3V1.h
  (SDA=21, SCL=22, PIN_BUTTON_1=0)
- Add new display driver: src/drivers/displays/ssd1306DisplayDriver.cpp
  (U8G2 SSD1306 128x64, 2 cyclic screens: mining stats + extended stats)
- Register new device in src/drivers/devices/device.h
- Register new driver in src/drivers/displays/displayDriver.h
- Register driver in src/drivers/displays/display.cpp
- Add new PlatformIO environment [env:LilygoT3V1] in platformio.ini

Tested on:
- Board: LilyGo T3 V1.6.1 
- Display: SSD1306 128x64 OLED (I2C)
- Mining confirmed working: ~350 KH/s, connected to public-pool.io

<img width="2048" height="1536" alt="image" src="https://github.com/user-attachments/assets/07737721-6092-4b90-8ea5-95edc1b04eae" />
<img width="2048" height="1536" alt="image" src="https://github.com/user-attachments/assets/2b17821b-d526-40f4-b6e1-9ad5de5ec22a" />


Note:
The LilyGo T3 V1.6.1 is a widely used board in the Meshtastic 
community due to its built-in LoRa module and OLED display. 
Many makers already own this board for Meshtastic projects, 
making it a natural fit for NerdMiner as well — no additional 
hardware needed beyond what they already have.