### PR TITLE
M5StickC Plus2: added power hold and removed an unused library

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -48,7 +48,6 @@ lib_deps =
 	https://github.com/takkaO/OpenFontRender#v1.2
 	mathertel/OneButton@^2.5.0
 	arduino-libraries/NTPClient@^3.2.1
-	m5stack/M5StickCPlus2
 lib_ignore = 
 	SD
 	SD_MMC

--- a/src/NerdMinerV2.ino.cpp
+++ b/src/NerdMinerV2.ino.cpp
@@ -60,6 +60,7 @@ const char* ntpServer = "pool.ntp.org";
 void setup()
 {
       //Init pin 15 to eneble 5V external power (LilyGo bug)
+      //Also used as power-hold latch on M5StickC Plus2 (GPIO4)
   #ifdef PIN_ENABLE5V
       pinMode(PIN_ENABLE5V, OUTPUT);
       digitalWrite(PIN_ENABLE5V, HIGH);

--- a/src/drivers/devices/M5Stick-C-Plus2.h
+++ b/src/drivers/devices/M5Stick-C-Plus2.h
@@ -4,6 +4,7 @@
 #define PIN_BUTTON_1 37
 #define PIN_BUTTON_2 39
 #define LED_PIN 19
+#define PIN_ENABLE5V 4
 
 #define V1_DISPLAY
 


### PR DESCRIPTION
Minor fixes for the M5StickC Plus2: added power hold on GPIO4 to prevent it from shutting down immediately after disconnecting the USB cable, and removed an unused library that pulled in a bunch of dependencies. I've tested it, and everything works as expected. Last pull request for today! :)
<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/05e26a65-b28a-47a1-a656-836964502cc4" />
