### PR TITLE
fix(monitor): route HTTPS to setInsecure WiFiClientSecure, HTTP to WiFiClient

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -3,7 +3,7 @@ name: Nerdminer Pre-Release
 on:
   push:
     branches:
-      - develop
+      - prerelease
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -121,17 +121,17 @@ Note: when BTC address of your selected wallet is not provided, mining will not 
 #### SD card (if available)
 
 1. Format a SD card using Fat32.
-1. Create a file named "config.json" in your card's root, containing the the following structure. Adjust the settings to your needs:  
+1. Create a file named "config.json" in your card's root, containing the the following structure. Adjust the settings to your needs:
 ```
-{  
-  "SSID": "myWifiSSID",  
-  "WifiPW": "myWifiPassword",  
-  "PoolUrl": "public-pool.io",  
-  "PoolPort": 21496,
+{
+  "SSID": "myWifiSSID",
+  "WifiPW": "myWifiPassword",
+  "PoolUrl": "public-pool.io",
+  "PoolPort": 3333,
   "PoolPassword": "x",
-  "BtcWallet": "walletID",  
-  "Timezone": 2,  
-  "SaveStats": false  
+  "BtcWallet": "walletID",
+  "Timezone": 2,
+  "SaveStats": false
 }
 ```
 
@@ -145,7 +145,7 @@ Recommended low difficulty share pools:
 
 | Pool URL          | Port  | Web URL                    | Status                                                             |
 | ----------------- | ----- | -------------------------- | ------------------------------------------------------------------ |
-| public-pool.io    | 21496 | https://web.public-pool.io | Open Source Solo Bitcoin Mining Pool supporting open source miners |
+| public-pool.io    | 3333 | https://web.public-pool.io | Open Source Solo Bitcoin Mining Pool supporting open source miners |
 | pool.nerdminers.org    | 3333  | https://nerdminers.org     | The official Nerdminer pool site - Mantained by @golden-guy |
 | pool.nerdminer.io | 3333  | https://nerdminer.io       | Mantained by CHMEX                                                 |
 | pool.pyblock.xyz  | 3333  | https://pool.pyblock.xyz/  | Mantained by curly60e                                              |

--- a/lib/TFT_eSPI/User_Setup_Select.h
+++ b/lib/TFT_eSPI/User_Setup_Select.h
@@ -149,6 +149,9 @@
 #ifdef LILYGO_S3_T_EMBED
 #include <User_Setups/Setup210_LilyGo_T_Embed_S3.h>         // For the LilyGo T-Embed S3 based ESP32S3 with ST7789 170 x 320 TFT
 #endif
+#ifdef M5_CARDPUTER_ADV
+#include <User_Setups/Setup215_M5_Cardputer_Adv.h>          // M5Stack Cardputer Adv (ESP32-S3) with ST7789V2 240 x 135 TFT
+#endif
 #ifdef NERDMINER_T_QT
 #include <User_Setups/Setup211_LilyGo_T_QT_Pro_S3.h>         // For the LilyGo T-QT Pro S3 based ESP32S3 with GC9A01 128 x 128 TFT
 #endif

--- a/lib/TFT_eSPI/User_Setups/Setup215_M5_Cardputer_Adv.h
+++ b/lib/TFT_eSPI/User_Setups/Setup215_M5_Cardputer_Adv.h
@@ -1,0 +1,31 @@
+// ST7789V2 240 x 135 display - M5Stack Cardputer Adv (ESP32-S3)
+#define USER_SETUP_ID 215
+
+#define ST7789_DRIVER
+
+#define TFT_WIDTH  135
+#define TFT_HEIGHT 240
+
+#define TFT_INVERSION_ON
+#define TFT_BACKLIGHT_ON 1
+
+#define TFT_MISO   -1
+#define TFT_MOSI   35
+#define TFT_SCLK   36
+#define TFT_CS     37
+#define TFT_DC     34
+#define TFT_RST    33
+#define TFT_BL     38
+
+#define LOAD_GLCD
+#define LOAD_FONT2
+#define LOAD_FONT4
+#define LOAD_FONT6
+#define LOAD_FONT7
+#define LOAD_FONT8
+#define LOAD_GFXFF
+
+#define SMOOTH_FONT
+
+#define SPI_FREQUENCY        40000000
+#define SPI_READ_FREQUENCY   20000000

--- a/platformio.ini
+++ b/platformio.ini
@@ -48,7 +48,6 @@ lib_deps =
 	https://github.com/takkaO/OpenFontRender#v1.2
 	mathertel/OneButton@^2.5.0
 	arduino-libraries/NTPClient@^3.2.1
-	m5stack/M5StickCPlus2
 lib_ignore = 
 	SD
 	SD_MMC

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,7 +11,7 @@
 [platformio]
 globallib_dir = lib
 
-default_envs =  NerdminerV2, NerdminerV2-T-HMI, wt32-sc01, wt32-sc01-plus, han_m5stack, M5Stick-C, M5Stick-C-Plus2, M5Stick-CPlus, esp32cam, ESP32-2432S028R, ESP32_2432S028_2USB, ESP32-2432S024, Lilygo-T-Embed, ESP32-devKitv1, NerdminerV2-S3-DONGLE, NerdminerV2-S3-GEEK, NerdminerV2-S3-AMOLED, NerdminerV2-S3-AMOLED-TOUCH, NerdminerV2-T-QT, NerdminerV2-T-Display_V1, TTGO-T-Display, M5-StampS3, ESP32-S3-devKitv1, ESP32-S3-mini-wemos, ESP32-S2-mini-wemos, ESP32-S3-mini-weact, ESP32-D0WD-V3-weact, ESP32-C3-super-mini, ESP32-C3-devKitmv1, ESP32-C3-042-OLED, ESP32-S3-042-OLED, ESP32-C3-spotpear, esp32-s3-devkitc1-n32r8
+default_envs =  NerdminerV2, NerdminerV2-T-HMI, wt32-sc01, wt32-sc01-plus, han_m5stack, M5Stick-C, M5Stick-C-Plus2, M5Stick-CPlus, esp32cam, ESP32-2432S028R, ESP32_2432S028_2USB, ESP32-2432S024, Lilygo-T-Embed, M5-Cardputer-Adv, ESP32-devKitv1, NerdminerV2-S3-DONGLE, NerdminerV2-S3-GEEK, NerdminerV2-S3-AMOLED, NerdminerV2-S3-AMOLED-TOUCH, NerdminerV2-T-QT, NerdminerV2-T-Display_V1, TTGO-T-Display, M5-StampS3, ESP32-S3-devKitv1, ESP32-S3-mini-wemos, ESP32-S2-mini-wemos, ESP32-S3-mini-weact, ESP32-D0WD-V3-weact, ESP32-C3-super-mini, ESP32-C3-devKitmv1, ESP32-C3-042-OLED, ESP32-S3-042-OLED, ESP32-C3-spotpear, esp32-s3-devkitc1-n32r8
 
 ; Global configuration for all environments
 [env]
@@ -1141,29 +1141,61 @@ framework = arduino
 extra_scripts =
     pre:auto_firmware_version.py
     post:post_build_merge.py
-monitor_filters = 
+monitor_filters =
 	esp32_exception_decoder
 	time
 	log2file
 monitor_speed = 115200
 upload_speed = 115200
 board_build.partitions = huge_app.csv
-build_flags = 
+build_flags =
 	-D ARDUINO_USB_MODE=1
 	-D ARDUINO_USB_CDC_ON_BOOT=1
 	-D ESP32RGB=1
 	-D RGB_LED_PIN=21
-lib_deps = 
+lib_deps =
 	bblanchon/ArduinoJson@^6.21.5
 	https://github.com/tzapu/WiFiManager.git#v2.0.17
 	mathertel/oneButton@^2.6.1
 	arduino-libraries/NTPClient@^3.2.1
 	fastled/FastLED@3.7.8
-lib_ignore = 
+lib_ignore =
 	TFT_eSPI
 	SD
 	rm67162
 	SPI
+	HANSOLOminerv2
+
+;--------------------------------------------------------------------
+
+[env:M5-Cardputer-Adv]
+platform = espressif32@6.6.0
+board = esp32-s3-devkitc-1
+framework = arduino
+extra_scripts =
+    pre:auto_firmware_version.py
+    post:post_build_merge.py
+monitor_filters =
+	esp32_exception_decoder
+	time
+	log2file
+monitor_speed = 115200
+upload_speed = 921600
+board_build.partitions = huge_app.csv
+board_build.flash_size = 8MB
+build_flags =
+	-D ARDUINO_USB_MODE=1
+	-D ARDUINO_USB_CDC_ON_BOOT=1
+	-D M5_CARDPUTER_ADV=1
+	-D SD_ID=HSPI
+	;-D DEBUG_MINING=1
+lib_deps =
+	https://github.com/takkaO/OpenFontRender#v1.2
+	bblanchon/ArduinoJson@^6.21.5
+	https://github.com/tzapu/WiFiManager.git#v2.0.17
+	mathertel/oneButton@^2.6.1
+	arduino-libraries/NTPClient@^3.2.1
+lib_ignore =
 	HANSOLOminerv2
 
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,7 +11,7 @@
 [platformio]
 globallib_dir = lib
 
-default_envs =  NerdminerV2, NerdminerV2-T-HMI, wt32-sc01, wt32-sc01-plus, han_m5stack, M5Stick-C, M5Stick-C-Plus2, M5Stick-CPlus, esp32cam, ESP32-2432S028R, ESP32_2432S028_2USB, ESP32-2432S024, Lilygo-T-Embed, ESP32-devKitv1, NerdminerV2-S3-DONGLE, NerdminerV2-S3-GEEK, NerdminerV2-S3-AMOLED, NerdminerV2-S3-AMOLED-TOUCH, NerdminerV2-T-QT, NerdminerV2-T-Display_V1, TTGO-T-Display, M5-StampS3, ESP32-S3-devKitv1, ESP32-S3-mini-wemos, ESP32-S2-mini-wemos, ESP32-S3-mini-weact, ESP32-D0WD-V3-weact, ESP32-C3-super-mini, ESP32-C3-devKitmv1, ESP32-C3-042-OLED, ESP32-S3-042-OLED, ESP32-C3-spotpear, esp32-s3-devkitc1-n32r8
+default_envs =  LilygoT3V1, NerdminerV2, NerdminerV2-T-HMI, wt32-sc01, wt32-sc01-plus, han_m5stack, M5Stick-C, M5Stick-C-Plus2, M5Stick-CPlus, esp32cam, ESP32-2432S028R, ESP32_2432S028_2USB, ESP32-2432S024, Lilygo-T-Embed, ESP32-devKitv1, NerdminerV2-S3-DONGLE, NerdminerV2-S3-GEEK, NerdminerV2-S3-AMOLED, NerdminerV2-S3-AMOLED-TOUCH, NerdminerV2-T-QT, NerdminerV2-T-Display_V1, TTGO-T-Display, M5-StampS3, ESP32-S3-devKitv1, ESP32-S3-mini-wemos, ESP32-S2-mini-wemos, ESP32-S3-mini-weact, ESP32-D0WD-V3-weact, ESP32-C3-super-mini, ESP32-C3-devKitmv1, ESP32-C3-042-OLED, ESP32-S3-042-OLED, ESP32-C3-spotpear, esp32-s3-devkitc1-n32r8
 
 ; Global configuration for all environments
 [env]
@@ -1106,6 +1106,32 @@ lib_deps =
 	bodmer/TFT_eSPI @ ^2.5.31
 	https://github.com/achillhasler/TFT_eTouch
 lib_ignore = 
+	HANSOLOminerv2
+
+;--------------------------------------------------------------------
+
+[env:LilygoT3V1]
+platform = espressif32@6.6.0
+board = ttgo-lora32-v21
+framework = arduino
+extra_scripts =
+    pre:auto_firmware_version.py
+    post:post_build_merge.py
+monitor_speed = 115200
+upload_speed = 921600
+board_build.partitions = huge_app.csv
+build_flags =
+	-D LILYGO_T3_V1=1
+	;-D DEBUG_MINING=1
+lib_deps =
+	https://github.com/takkaO/OpenFontRender#v1.2
+	bblanchon/ArduinoJson@^6.21.5
+	https://github.com/tzapu/WiFiManager.git#v2.0.17
+	mathertel/oneButton@^2.6.1
+	arduino-libraries/NTPClient@^3.2.1
+	olikraus/U8g2@^2.34.17
+lib_ignore =
+	TFT_eSPI
 	HANSOLOminerv2
 
 ;--------------------------------------------------------------------

--- a/src/NerdMinerV2.ino.cpp
+++ b/src/NerdMinerV2.ino.cpp
@@ -60,6 +60,7 @@ const char* ntpServer = "pool.ntp.org";
 void setup()
 {
       //Init pin 15 to eneble 5V external power (LilyGo bug)
+      //Also used as power-hold latch on M5StickC Plus2 (GPIO4)
   #ifdef PIN_ENABLE5V
       pinMode(PIN_ENABLE5V, OUTPUT);
       digitalWrite(PIN_ENABLE5V, HIGH);

--- a/src/drivers/devices/M5Stick-C-Plus2.h
+++ b/src/drivers/devices/M5Stick-C-Plus2.h
@@ -4,6 +4,7 @@
 #define PIN_BUTTON_1 37
 #define PIN_BUTTON_2 39
 #define LED_PIN 19
+#define PIN_ENABLE5V 4
 
 #define V1_DISPLAY
 

--- a/src/drivers/devices/device.h
+++ b/src/drivers/devices/device.h
@@ -23,6 +23,8 @@
 #include "lilygoS3Dongle.h"
 #elif defined(LILYGO_S3_T_EMBED)
 #include "lilygoS3TEmbed.h"
+#elif defined(M5_CARDPUTER_ADV)
+#include "m5CardputerAdv.h"
 #elif defined(ESP32_2432S028R)
 #include "esp322432s028r.h"
 #elif defined(ESP32_2432S028_2USB) // For another type of ESP32_2432S028 version with 2 USB connectors

--- a/src/drivers/devices/device.h
+++ b/src/drivers/devices/device.h
@@ -53,6 +53,8 @@
 #include "lilygoT_HMI.h"
 #elif defined(SPOTPEAR)
 #include "spotpearKeychain.h"
+#elif defined(LILYGO_T3_V1)
+#include "lilygoT3V1.h"
 
 #else
 #error "No device defined"

--- a/src/drivers/devices/lilygoT3V1.h
+++ b/src/drivers/devices/lilygoT3V1.h
@@ -1,0 +1,12 @@
+#ifndef _LILYGO_T3_V1_H
+#define _LILYGO_T3_V1_H
+
+// LilyGo T3 V1.6.1 - SSD1306 128x64 OLED (I2C)
+#define SDA_PIN 21
+#define SCL_PIN 22
+
+#define PIN_BUTTON_1 0
+
+#define OLED_SSD1306_128X64_DISPLAY
+
+#endif

--- a/src/drivers/devices/m5CardputerAdv.h
+++ b/src/drivers/devices/m5CardputerAdv.h
@@ -1,0 +1,13 @@
+#ifndef _M5_CARDPUTER_ADV_H
+#define _M5_CARDPUTER_ADV_H
+
+#define PIN_BUTTON_1 0
+
+#define V1_DISPLAY
+
+#define SDSPI_CS    12
+#define SDSPI_MOSI  14
+#define SDSPI_CLK   40
+#define SDSPI_MISO  39
+
+#endif

--- a/src/drivers/displays/display.cpp
+++ b/src/drivers/displays/display.cpp
@@ -64,6 +64,10 @@ DisplayDriver *currentDisplayDriver = &t_hmiDisplayDriver;
 DisplayDriver *currentDisplayDriver = &sp_kcDisplayDriver;
 #endif
 
+#ifdef OLED_SSD1306_128X64_DISPLAY
+DisplayDriver *currentDisplayDriver = &ssd1306DisplayDriver;
+#endif
+
 
 // Initialize the display
 void initDisplay()

--- a/src/drivers/displays/displayDriver.h
+++ b/src/drivers/displays/displayDriver.h
@@ -43,6 +43,7 @@ extern DisplayDriver m5stickCDriver;
 extern DisplayDriver m5stickCPlusDriver;
 extern DisplayDriver t_hmiDisplayDriver;
 extern DisplayDriver sp_kcDisplayDriver;
+extern DisplayDriver ssd1306DisplayDriver;
 
 #define SCREENS_ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 

--- a/src/drivers/displays/ssd1306DisplayDriver.cpp
+++ b/src/drivers/displays/ssd1306DisplayDriver.cpp
@@ -1,0 +1,132 @@
+
+#include "displayDriver.h"
+
+#ifdef OLED_SSD1306_128X64_DISPLAY
+
+#include <U8g2lib.h>
+#include "monitor.h"
+
+#ifdef U8X8_HAVE_HW_I2C
+#include <Wire.h>
+#endif
+
+U8G2_SSD1306_128X64_NONAME_F_HW_I2C u8g2(U8G2_R0, /* reset=*/ U8X8_PIN_NONE);
+
+void ssd1306_clearScreen(void) {
+    u8g2.clearBuffer();
+    u8g2.sendBuffer();
+}
+
+void serialPrint_ssd1306(unsigned long mElapsed) {
+  mining_data data = getMiningData(mElapsed);
+  Serial.printf(">>> Hashrate: %s KH/s | Shares: %s | Best diff: %s\n",
+                data.currentHashRate.c_str(), data.completedShares.c_str(), data.bestDiff.c_str());
+}
+
+void ssd1306Display_Init(void) {
+  Serial.println("SSD1306 128x64 display driver initialized");
+  Wire.begin(SDA_PIN, SCL_PIN);
+  u8g2.begin();
+  u8g2.clear();
+  ssd1306_clearScreen();
+}
+
+void ssd1306Display_AlternateScreenState(void) {}
+void ssd1306Display_AlternateRotation(void) {}
+
+void ssd1306Display_Screen1(unsigned long mElapsed) {
+  mining_data data = getMiningData(mElapsed);
+
+  u8g2.clearBuffer();
+
+  // Header
+  u8g2.setFont(u8g2_font_6x10_tf);
+  u8g2.drawStr(0, 10, "NERDMINER v2");
+  u8g2.drawHLine(0, 12, 128);
+
+  // Hashrate (big)
+  u8g2.setFont(u8g2_font_helvB18_tf);
+  u8g2.drawStr(0, 38, data.currentHashRate.c_str());
+  u8g2.setFont(u8g2_font_6x10_tf);
+  u8g2.drawStr(90, 38, "KH/s");
+
+  // Bottom line: shares and best diff
+  u8g2.drawHLine(0, 50, 128);
+  u8g2.setFont(u8g2_font_5x7_tf);
+  String shares = "Shares: " + data.completedShares;
+  String bestDiff = "Best: " + data.bestDiff;
+  u8g2.drawStr(0, 62, shares.c_str());
+  u8g2.drawStr(70, 62, bestDiff.c_str());
+
+  u8g2.sendBuffer();
+  serialPrint_ssd1306(mElapsed);
+}
+
+void ssd1306Display_Screen2(unsigned long mElapsed) {
+  mining_data data = getMiningData(mElapsed);
+
+  u8g2.clearBuffer();
+
+  u8g2.setFont(u8g2_font_6x10_tf);
+  u8g2.drawStr(0, 10, "MINING STATS");
+  u8g2.drawHLine(0, 12, 128);
+
+  u8g2.setFont(u8g2_font_5x7_tf);
+  String hashrate = "Hashrate: " + data.currentHashRate + " KH/s";
+  String hashes   = "Total MH: " + data.totalMHashes;
+  String uptime   = "Uptime: " + data.timeMining;
+  String temp     = "Temp: " + data.temp + " C";
+
+  u8g2.drawStr(0, 26, hashrate.c_str());
+  u8g2.drawStr(0, 36, hashes.c_str());
+  u8g2.drawStr(0, 46, uptime.c_str());
+  u8g2.drawStr(0, 56, temp.c_str());
+
+  u8g2.sendBuffer();
+  serialPrint_ssd1306(mElapsed);
+}
+
+void ssd1306Display_LoadingScreen(void) {
+  Serial.println("Loading...");
+  u8g2.clearBuffer();
+  u8g2.setFont(u8g2_font_helvB18_tf);
+  u8g2.drawStr(10, 30, "NERD");
+  u8g2.drawStr(10, 55, "MINER");
+  u8g2.sendBuffer();
+}
+
+void ssd1306Display_SetupScreen(void) {
+  Serial.println("Setup mode...");
+  u8g2.clearBuffer();
+  u8g2.setFont(u8g2_font_6x10_tf);
+  u8g2.drawStr(20, 20, "SETUP MODE");
+  u8g2.drawStr(5, 35, "Connect to WiFi:");
+  u8g2.drawStr(5, 48, "NerdMinerAP");
+  u8g2.drawStr(5, 61, "MineYourCoins");
+  u8g2.sendBuffer();
+}
+
+void ssd1306Display_DoLedStuff(unsigned long frame) {}
+void ssd1306Display_AnimateCurrentScreen(unsigned long frame) {}
+
+CyclicScreenFunction ssd1306DisplayCyclicScreens[] = {
+    ssd1306Display_Screen1,
+    ssd1306Display_Screen2
+};
+
+DisplayDriver ssd1306DisplayDriver = {
+    ssd1306Display_Init,
+    ssd1306Display_AlternateScreenState,
+    ssd1306Display_AlternateRotation,
+    ssd1306Display_LoadingScreen,
+    ssd1306Display_SetupScreen,
+    ssd1306DisplayCyclicScreens,
+    ssd1306Display_AnimateCurrentScreen,
+    ssd1306Display_DoLedStuff,
+    SCREENS_ARRAY_SIZE(ssd1306DisplayCyclicScreens),
+    0,
+    128,
+    64,
+};
+
+#endif

--- a/src/drivers/storage/storage.h
+++ b/src/drivers/storage/storage.h
@@ -15,7 +15,7 @@
 #define DEFAULT_POOLURL		"public-pool.io"
 #define DEFAULT_POOLPASS	"x"
 #define DEFAULT_WALLETID	"yourBtcAddress"
-#define DEFAULT_POOLPORT	21496
+#define DEFAULT_POOLPORT	3333
 #define DEFAULT_TIMEZONE	2
 #define DEFAULT_SAVESTATS	false
 #define DEFAULT_INVERTCOLORS	false

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -2,12 +2,53 @@
 #include <WiFi.h>
 #include "mbedtls/md.h"
 #include "HTTPClient.h"
+#include <WiFiClientSecure.h>
 #include <NTPClient.h>
 #include <WiFiUdp.h>
 #include <list>
 #include "mining.h"
 #include "utils.h"
 #include "monitor.h"
+
+// ---------------------------------------------------------------------------
+//  HTTPClient routing helper
+//
+//  Upstream NerdMiner used `http.begin(url)`, which made HTTPClient build
+//  its own default transport. That broke two real-world cases:
+//
+//    1. https:// endpoints (public-pool.io:40557, mempool.space, etc.)
+//       failed handshake with "start_ssl_client: -1" because the default
+//       WiFiClientSecure verifies TLS certificates against a CA bundle
+//       that the firmware never installs. Result: getCoinData() /
+//       updateGlobalData() / getPoolData() silently never populated.
+//
+//    2. plain http:// endpoints (e.g. a local Umbrel/Start9 pool at
+//       http://192.168.x.x:2019/api/client/) failed with -29184 "SSL
+//       invalid record" when the same path forced a TLS handshake on a
+//       plain socket.
+//
+//  httpBeginAny() inspects the URL prefix and picks the right transport:
+//      https://  ->  WiFiClientSecure with setInsecure()
+//      http://   ->  WiFiClient (plain)
+//
+//  Trade-off on https: connection is encrypted but not authenticated.
+//  Acceptable for read-only public mining stats. If a deployment needs
+//  full validation, replace setInsecure() with setCACert() per endpoint.
+// ---------------------------------------------------------------------------
+static WiFiClient       sPlainClient;
+static WiFiClientSecure sSecureClient;
+static bool             sSecureClientInited = false;
+
+static bool httpBeginAny(HTTPClient &http, const String &url) {
+    if (url.startsWith("https://")) {
+        if (!sSecureClientInited) {
+            sSecureClient.setInsecure();
+            sSecureClientInited = true;
+        }
+        return http.begin(sSecureClient, url);
+    }
+    return http.begin(sPlainClient, url);
+}
 #include "drivers/storage/storage.h"
 #include "drivers/devices/device.h"
 
@@ -66,7 +107,7 @@ void updateGlobalData(void){
         HTTPClient http;
         http.setTimeout(10000);
         try {
-        http.begin(getGlobalHash);
+        jc_http_begin(http, String(getGlobalHash));
         int httpCode = http.GET();
 
         if (httpCode == HTTP_CODE_OK) {
@@ -91,7 +132,7 @@ void updateGlobalData(void){
 
       
         //Make third API call to get fees
-        http.begin(getFees);
+        jc_http_begin(http, String(getFees));
         httpCode = http.GET();
 
         if (httpCode == HTTP_CODE_OK) {
@@ -131,7 +172,7 @@ String getBlockHeight(void){
         HTTPClient http;
         http.setTimeout(10000);
         try {
-        http.begin(getHeightAPI);
+        jc_http_begin(http, String(getHeightAPI));
         int httpCode = http.GET();
 
         if (httpCode == HTTP_CODE_OK) {
@@ -169,7 +210,7 @@ String getBTCprice(void){
         bool priceUpdated = false;
 
         try {
-        http.begin(getBTCAPI);
+        jc_http_begin(http, String(getBTCAPI));
         int httpCode = http.GET();
 
         if (httpCode == HTTP_CODE_OK) {
@@ -449,9 +490,9 @@ pool_data getPoolData(void){
           if (btcWallet.indexOf(".")>0) btcWallet = btcWallet.substring(0,btcWallet.indexOf("."));
 #ifdef SCREEN_WORKERS_ENABLE
           Serial.println("Pool API : " + poolAPIUrl+btcWallet);
-          http.begin(poolAPIUrl+btcWallet);
+          jc_http_begin(http, poolAPIUrl+btcWallet);
 #else
-          http.begin(String(getPublicPool)+btcWallet);
+          jc_http_begin(http, String(getPublicPool)+btcWallet);
 #endif
           int httpCode = http.GET();
           if (httpCode == HTTP_CODE_OK) {

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -107,7 +107,7 @@ void updateGlobalData(void){
         HTTPClient http;
         http.setTimeout(10000);
         try {
-        jc_http_begin(http, String(getGlobalHash));
+        httpBeginAny(http, String(getGlobalHash));
         int httpCode = http.GET();
 
         if (httpCode == HTTP_CODE_OK) {
@@ -132,7 +132,7 @@ void updateGlobalData(void){
 
       
         //Make third API call to get fees
-        jc_http_begin(http, String(getFees));
+        httpBeginAny(http, String(getFees));
         httpCode = http.GET();
 
         if (httpCode == HTTP_CODE_OK) {
@@ -172,7 +172,7 @@ String getBlockHeight(void){
         HTTPClient http;
         http.setTimeout(10000);
         try {
-        jc_http_begin(http, String(getHeightAPI));
+        httpBeginAny(http, String(getHeightAPI));
         int httpCode = http.GET();
 
         if (httpCode == HTTP_CODE_OK) {
@@ -210,7 +210,7 @@ String getBTCprice(void){
         bool priceUpdated = false;
 
         try {
-        jc_http_begin(http, String(getBTCAPI));
+        httpBeginAny(http, String(getBTCAPI));
         int httpCode = http.GET();
 
         if (httpCode == HTTP_CODE_OK) {
@@ -490,9 +490,9 @@ pool_data getPoolData(void){
           if (btcWallet.indexOf(".")>0) btcWallet = btcWallet.substring(0,btcWallet.indexOf("."));
 #ifdef SCREEN_WORKERS_ENABLE
           Serial.println("Pool API : " + poolAPIUrl+btcWallet);
-          jc_http_begin(http, poolAPIUrl+btcWallet);
+          httpBeginAny(http, poolAPIUrl+btcWallet);
 #else
-          jc_http_begin(http, String(getPublicPool)+btcWallet);
+          httpBeginAny(http, String(getPublicPool)+btcWallet);
 #endif
           int httpCode = http.GET();
           if (httpCode == HTTP_CODE_OK) {


### PR DESCRIPTION
Upstream NerdMiner's http.begin(url) relies on Arduino-ESP32 HTTPClient's internal default WiFiClientSecure. Two problems with that:

1. HTTPS endpoints (public-pool.io:40557, mempool.space, blockchain.info) fail handshake with 'start_ssl_client: -1' because the default client verifies TLS certificates against a CA bundle that isn't installed. Result: getCoinData(), getGlobalData(), getPoolData() etc. silently never populate — boards show all zeros / defaults forever.

2. Plain HTTP endpoints (e.g. local Umbrel/Start9 pool at port 2019, reached via http://192.168.x.x:2019/api/...) fail with 'SSL invalid record' (-29184) when the same code path forces TLS handshake on a plain socket.

This patch adds httpBeginAny() which routes by URL prefix:
- https:// -> WiFiClientSecure with setInsecure()
- http://  -> WiFiClient (plain)

Affects all NerdMiner_v2 boards that fetch live data over HTTP(S). Particularly visible on boards with local pool setups.