### PR TITLE
fix: exponential backoff pool reconnect + disable wifi modem sleep

### DIFF
--- a/src/mining.cpp
+++ b/src/mining.cpp
@@ -251,8 +251,12 @@ void runStratumWorker(void *name) {
   uint32_t job_pool = 0xFFFFFFFF;
   uint32_t last_job_time = millis();
 
+  //Exponential backoff for pool reconnects: resume fast after a short glitch
+  //(1s, 2s, 4s...) but stay gentle with the pool if it is really down (cap 15s).
+  uint32_t pool_retry_delay_s = 1;
+
   while(true) {
-      
+
     if(WiFi.status() != WL_CONNECTED){
       // WiFi is disconnected, so reconnect now
       mMonitor.NerdStatus = NM_Connecting;
@@ -260,15 +264,17 @@ void runStratumWorker(void *name) {
       WiFi.reconnect();
       vTaskDelay(5000 / portTICK_PERIOD_MS);
       continue;
-    } 
+    }
 
     if(!checkPoolConnection()){
-      //If server is not reachable add random delay for connection retries
-      //Generate value between 1 and 60 secs
       MiningJobStop(job_pool, s_submition_map);
-      vTaskDelay(((1 + rand() % 60) * 1000) / portTICK_PERIOD_MS);
+      Serial.printf("Pool unreachable, retrying in %us\n", pool_retry_delay_s);
+      vTaskDelay((pool_retry_delay_s * 1000) / portTICK_PERIOD_MS);
+      if (pool_retry_delay_s < 15)
+        pool_retry_delay_s *= 2;
       continue;
     }
+    pool_retry_delay_s = 1; //connected: next incident restarts from 1s
 
     if(!isMinerSuscribed)
     {

--- a/src/wManager.cpp
+++ b/src/wManager.cpp
@@ -436,6 +436,9 @@ void wifiManagerProcess() {
     if (newStatus != oldStatus) {
         if (newStatus == WL_CONNECTED) {
             Serial.println("CONNECTED - Current ip: " + WiFi.localIP().toString());
+            //Modem power save (default) drops frames on weak links, causing pool
+            //disconnects. An always-powered miner prefers a stable link (~+60mA).
+            WiFi.setSleep(false);
         } else {
             Serial.print("[Error] - current status: ");
             Serial.println(newStatus);


### PR DESCRIPTION
Two independent reliability fixes for miners that briefly lose the pool connection (common on weak wifi links).

## 1. Exponential backoff instead of a random 1-60 s sleep

On a failed `checkPoolConnection()` the stratum worker slept a random `1 + rand()%60` seconds before retrying. A brief socket drop could idle the miner (hashrate 0) for up to a minute. Replaced with 1 s, 2 s, 4 s… capped at 15 s, reset to 1 s once connected: short glitches now cost a few seconds of hashing instead of up to a minute, while a pool that is really down still only sees a request every 15 s.

## 2. Disable wifi modem power save once connected

`WiFi.setSleep(false)` right after connecting. Modem sleep (the default) drops frames on weak links, which causes periodic pool socket drops on miners far from the AP. A mains-powered miner prefers a stable link over the ~60 mA saving.
