### PR TITLE
Add support for LilyGo T-Embed CC1101 & plus (fixes blank screen)

### DIFF
--- a/lib/TFT_eSPI/User_Setup_Select.h
+++ b/lib/TFT_eSPI/User_Setup_Select.h
@@ -149,6 +149,9 @@
 #ifdef LILYGO_S3_T_EMBED
 #include <User_Setups/Setup210_LilyGo_T_Embed_S3.h>         // For the LilyGo T-Embed S3 based ESP32S3 with ST7789 170 x 320 TFT
 #endif
+#ifdef LILYGO_S3_T_EMBED_CC1101
+#include <User_Setups/Setup216_LilyGo_T_Embed_CC1101.h>
+#endif
 #ifdef M5_CARDPUTER_ADV
 #include <User_Setups/Setup215_M5_Cardputer_Adv.h>          // M5Stack Cardputer Adv (ESP32-S3) with ST7789V2 240 x 135 TFT
 #endif

--- a/lib/TFT_eSPI/User_Setups/Setup216_LilyGo_T_Embed_CC1101.h
+++ b/lib/TFT_eSPI/User_Setups/Setup216_LilyGo_T_Embed_CC1101.h
@@ -1,0 +1,36 @@
+// ST7789 170 x 320 display
+// LilyGo T-Embed **CC1101** variant - this board's LCD pins are different
+// from the plain (non-CC1101) T-Embed, see:
+// https://github.com/Xinyuan-LilyGO/T-Embed-CC1101#4-pins
+#define USER_SETUP_ID 216
+
+#define ST7789_DRIVER     // Configure all registers
+
+#define TFT_WIDTH  170
+#define TFT_HEIGHT 320
+
+#define TFT_INVERSION_ON
+#define TFT_BACKLIGHT_ON 1
+
+#define TFT_BL     21   // LED back-light (DISPLAY_BL)
+#define TFT_MISO   -1   // Not connected
+#define TFT_MOSI    9   // DISPLAY_MOSI
+#define TFT_SCLK   11   // DISPLAY_SCLK
+#define TFT_CS     41   // DISPLAY_CS
+#define TFT_DC     16   // DISPLAY_DC
+#define TFT_RST    -1   // DISPLAY_RST - not wired to a GPIO on this board,
+                         // display uses power-on reset only
+
+#define LOAD_GLCD
+#define LOAD_FONT2
+#define LOAD_FONT4
+#define LOAD_FONT6
+#define LOAD_FONT7
+#define LOAD_FONT8
+#define LOAD_GFXFF
+
+#define SMOOTH_FONT
+
+#define SPI_FREQUENCY  40000000
+#define SPI_READ_FREQUENCY  20000000
+#define SPI_TOUCH_FREQUENCY  2500000

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,7 +11,7 @@
 [platformio]
 globallib_dir = lib
 
-default_envs = LilygoT3V1, NerdminerV2, NerdminerV2-T-HMI, wt32-sc01, wt32-sc01-plus, han_m5stack, M5Stick-C, M5Stick-C-Plus2, M5Stick-CPlus, esp32cam, ESP32-2432S028R, ESP32_2432S028_2USB, ESP32-2432S024, Lilygo-T-Embed, M5-Cardputer-Adv, ESP32-devKitv1, NerdminerV2-S3-DONGLE, NerdminerV2-S3-GEEK, NerdminerV2-S3-AMOLED, NerdminerV2-S3-AMOLED-TOUCH, NerdminerV2-T-QT, NerdminerV2-T-Display_V1, TTGO-T-Display, M5-StampS3, ESP32-S3-devKitv1, ESP32-S3-mini-wemos, ESP32-S2-mini-wemos, ESP32-S3-mini-weact, ESP32-D0WD-V3-weact, ESP32-C3-super-mini, ESP32-C3-devKitmv1, ESP32-C3-042-OLED, ESP32-S3-042-OLED, ESP32-C3-spotpear, esp32-s3-devkitc1-n32r8
+default_envs = LilygoT3V1, NerdminerV2, NerdminerV2-T-HMI, wt32-sc01, wt32-sc01-plus, han_m5stack, M5Stick-C, M5Stick-C-Plus2, M5Stick-CPlus, esp32cam, ESP32-2432S028R, ESP32_2432S028_2USB, ESP32-2432S024, Lilygo-T-Embed, Lilygo-T-Embed-CC1101, M5-Cardputer-Adv, ESP32-devKitv1, NerdminerV2-S3-DONGLE, NerdminerV2-S3-GEEK, NerdminerV2-S3-AMOLED, NerdminerV2-S3-AMOLED-TOUCH, NerdminerV2-T-QT, NerdminerV2-T-Display_V1, TTGO-T-Display, M5-StampS3, ESP32-S3-devKitv1, ESP32-S3-mini-wemos, ESP32-S2-mini-wemos, ESP32-S3-mini-weact, ESP32-D0WD-V3-weact, ESP32-C3-super-mini, ESP32-C3-devKitmv1, ESP32-C3-042-OLED, ESP32-S3-042-OLED, ESP32-C3-spotpear, esp32-s3-devkitc1-n32r8
 
 ; Global configuration for all environments
 [env]
@@ -667,6 +667,42 @@ lib_deps =
 	https://github.com/takkaO/OpenFontRender#v1.2
 	bblanchon/ArduinoJson@^6.21.5
 	https://github.com/tzapu/WiFiManager.git#v2.0.17
+	matherte1/oneButton@^2.6.1
+	arduino-libraries/NTPClient@^3.2.1
+lib_ignore = 
+	HANSOLOminerv2
+
+;--------------------------------------------------------------------
+
+[env:Lilygo-T-Embed-CC1101]
+platform = espressif32@6.6.0
+board = esp32-s3-devkitc-1
+framework = arduino
+extra_scripts =
+    pre:auto_firmware_version.py
+    post:post_build_merge.py
+monitor_filters = 
+	esp32_exception_decoder
+	time
+	log2file
+board_build.arduino.memory_type = qio_opi
+monitor_speed = 115200
+upload_speed = 115200
+board_build.partitions = huge_app.csv
+build_flags = 
+	-D LV_LVGL_H_INCLUDE_SIMPLE
+	-D BOARD_HAS_PSRAM
+	-D ARDUINO_USB_MODE=1
+	-D ARDUINO_USB_CDC_ON_BOOT=1
+	-D LILYGO_S3_T_EMBED_CC1101=1
+lib_deps = 
+	https://github.com/takkaO/OpenFontRender#v1.2
+	bblanchon/ArduinoJson@^6.21.5
+	https://github.com/tzapu/WiFiManager.git#v2.0.17
+	matherte1/oneButton@^2.6.1
+	arduino-libraries/NTPClient@^3.2.1
+lib_ignore = 
+	HANSOLOminerv2
 	mathertel/oneButton@^2.6.1
 	arduino-libraries/NTPClient@^3.2.1
 lib_ignore = 

--- a/src/drivers/devices/device.h
+++ b/src/drivers/devices/device.h
@@ -23,6 +23,8 @@
 #include "lilygoS3Dongle.h"
 #elif defined(LILYGO_S3_T_EMBED)
 #include "lilygoS3TEmbed.h"
+#elif defined(LILYGO_S3_T_EMBED_CC1101)
+#include "lilygoS3TEmbedCC1101.h"
 #elif defined(M5_CARDPUTER_ADV)
 #include "m5CardputerAdv.h"
 #elif defined(ESP32_2432S028R)

--- a/src/drivers/devices/lilygoS3TEmbedCC1101.h
+++ b/src/drivers/devices/lilygoS3TEmbedCC1101.h
@@ -1,0 +1,10 @@
+#ifndef _LILYGO_S3_T_EMBED_CC1101_H
+#define _LILYGO_S3_T_EMBED_CC1101_H
+
+// LilyGo T-Embed CC1101 - pins per https://github.com/Xinyuan-LilyGO/T-Embed-CC1101#4-pins
+#define PIN_BUTTON_1 0    // ENCODER_KEY - rotary encoder push button
+#define PIN_ENABLE5V 15   // BOARD_PWR_EN - enables power to the board peripherals (incl. display)
+
+#define T_DISPLAY
+
+#endif

--- a/src/drivers/displays/tDisplayDriver.cpp
+++ b/src/drivers/displays/tDisplayDriver.cpp
@@ -27,7 +27,7 @@ void tDisplay_Init(void)
 #endif
   
   tft.init();
-  #ifdef LILYGO_S3_T_EMBED
+  #if defined(LILYGO_S3_T_EMBED) || defined(LILYGO_S3_T_EMBED_CC1101)
   tft.setRotation(ROTATION_270);
   #else
   tft.setRotation(ROTATION_90);


### PR DESCRIPTION
The existing Lilygo-T-Embed environment is wired for the plain, non-CC1101
T-Embed's LCD pins. The T-Embed CC1101 is a different PCB revision with a
different pinout (confirmed against LilyGO's own repo:
https://github.com/Xinyuan-LilyGO/T-Embed-CC1101#4-pins), so flashing the
existing firmware onto CC1101 hardware results in a completely blank screen
— WiFi/mining still work fine since none of that touches the display pins.

This adds a separate Lilygo-T-Embed-CC1101 environment rather than editing
the existing one, so the plain T-Embed is untouched:

- New: lib/TFT_eSPI/User_Setups/Setup216_LilyGo_T_Embed_CC1101.h — correct LCD pins
- New: src/drivers/devices/lilygoS3TEmbedCC1101.h — button + BOARD_PWR_EN pin
- Edited: User_Setup_Select.h, device.h, tDisplayDriver.cpp, platformio.ini — wire the new env in

Tested on my own T-Embed CC1101 board — screen and mining both confirmed working.